### PR TITLE
Add CodeRabbit review rules for endpoint docs and changelog coverage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+tone_instructions: "Be direct, concise, and specific. Prioritize correctness, public API compatibility, security, and missing documentation."
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  poem: false
+  in_progress_fortune: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!dist/**"
+    - "!apps/docs/dist/**"
+    - "!apps/docs/.wrangler/**"
+    - "!apps/docs/node_modules/**"
+    - "!apps/docs/.source/**"
+  path_instructions:
+    - path: "src/routes/**/*.{ts,tsx}"
+      instructions: |
+        Treat these files as public REST endpoint handlers. Focus on request validation, authentication behavior, cache key correctness, response shape stability, status codes, pagination, filtering, sorting, regional behavior, and error semantics.
+
+        For any structural public endpoint change, require matching documentation updates in `apps/docs/`, OpenAPI updates under `openapi/` or `src/openapi/`, and a `CHANGELOG.md` entry under `Unreleased`. Structural changes include adding, removing, or renaming routes, methods, query/path/body parameters, filters, sort options, response fields, response status codes, auth requirements, documented error behavior, pagination behavior, or deprecations.
+    - path: "src/openapi/**/*.{ts,json}"
+      instructions: |
+        Ensure the OpenAPI contract stays synchronized with the route implementation and the public docs in `apps/docs/`. Flag missing request parameters, response fields, auth metadata, visibility metadata, examples, and stale generated output.
+    - path: "openapi/**/*.json"
+      instructions: |
+        Review generated OpenAPI output for consistency with `src/openapi/`, route behavior, and `apps/docs/`. Flag stale or incomplete contract snapshots.
+    - path: "apps/docs/**/*.{md,mdx,ts,tsx,json,jsonc}"
+      instructions: |
+        Review documentation for public API accuracy. When endpoint structure changes, verify the docs describe the new request parameters, filters, response fields, auth requirements, errors, pagination, deprecations, and examples. Cross-check against OpenAPI where applicable.
+    - path: "CHANGELOG.md"
+      instructions: |
+        Keep entries concise and user-facing. New entries should go under `Unreleased` and mention public API, documentation, release policy, and maintenance changes that affect users or maintainers.
+  pre_merge_checks:
+    custom_checks:
+      - mode: "error"
+        name: "Changelog updated"
+        instructions: |
+          Fail if the PR changes application code, public API contracts, documentation, scripts, CI/workflow files, release policy, repository instructions, or CodeRabbit configuration without also changing `CHANGELOG.md`.
+
+          Pass if `CHANGELOG.md` is changed, or if the PR only changes test fixtures/snapshots, generated build output, dependency install artifacts, or formatting with no user-facing or maintainer-facing effect. If the PR uses a skip-changelog label, mention that CI may allow it but still report whether `CHANGELOG.md` is missing.
+      - mode: "error"
+        name: "Endpoint docs updated"
+        instructions: |
+          Fail if the PR changes `src/routes/**` or `src/openapi/**` in a way that changes public endpoint structure and does not also update both:
+          - documentation under `apps/docs/`
+          - the OpenAPI contract under `openapi/` or `src/openapi/`
+
+          Public endpoint structure includes routes, HTTP methods, query/path/body parameters, filters, sort options, request validation, response fields, status codes, authentication behavior, pagination behavior, documented errors, and deprecations.
+
+          Pass if the route/OpenAPI changes are internal refactors with no public request, response, auth, error, or documentation impact. If evidence is mixed, mark the check Inconclusive and explain exactly which docs or contract files appear to be missing.
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "docs/release-policy.md"
+
+chat:
+  auto_reply: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,9 @@
 
 ## API / Docs Checklist
 
-- [ ] Public API behavior changed: `CHANGELOG.md` or `.changeset/*.md` updated.
-- [ ] OpenAPI updated with request, response, auth, and visibility metadata.
+- [ ] `CHANGELOG.md` updated under `Unreleased` for this change.
+- [ ] Public endpoint structure changed: `apps/docs/` updated.
+- [ ] Public endpoint structure changed: OpenAPI updated with request, response, auth, and visibility metadata.
 - [ ] Contract snapshots or route coverage updated when public routes changed.
 - [ ] Not applicable: this PR has no public API or docs impact.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,20 @@ pnpm biome check .
 pnpm biome check --write .
 ```
 
+## Documentation & Release Policy
+
+Every user-facing or maintainer-facing change should add a concise entry to `CHANGELOG.md` under `Unreleased`.
+
+Any structural public endpoint change must also update the public docs in `apps/docs/` and the OpenAPI contract in `src/openapi/` or `openapi/`. Structural endpoint changes include adding, removing, or renaming routes, HTTP methods, query/path/body parameters, filters, sort options, request validation, response fields, status codes, authentication requirements, pagination behavior, documented errors, or deprecations.
+
+When changing public routes, run the relevant checks before handoff:
+
+```bash
+pnpm openapi:generate
+pnpm docs:check
+pnpm release:check
+```
+
 ## Architecture
 
 ### Framework & Runtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ pnpm biome check --write .
 
 ## Documentation & Release Policy
 
-Every user-facing or maintainer-facing change should add a concise entry to `CHANGELOG.md` under `Unreleased`.
+Every user-facing or maintainer-facing change must include a concise entry to `CHANGELOG.md` under `Unreleased`.
 
 Any structural public endpoint change must also update the public docs in `apps/docs/` and the OpenAPI contract in `src/openapi/` or `openapi/`. Structural endpoint changes include adding, removing, or renaming routes, HTTP methods, query/path/body parameters, filters, sort options, request validation, response fields, status codes, authentication requirements, pagination behavior, documented errors, or deprecations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable public API, documentation, release, and sustainability changes shoul
 
 ## Unreleased
 
+- Added CodeRabbit configuration to enforce changelog updates and docs/OpenAPI coverage for public endpoint structure changes.
+- Tightened the release policy so user-facing and maintainer-facing changes require `CHANGELOG.md` entries.
 - Added an API-owned OpenAPI contract for the first public REST documentation slice.
 - Added an in-repo Fumadocs docs app scaffold under `apps/docs`.
 - Added OpenAPI, route coverage, README command, and lightweight release policy checks.
-

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -2,13 +2,19 @@
 
 egdata API uses a lightweight release process while the public contract is being stabilized.
 
+## Changelog
+
+Every user-facing or maintainer-facing change must include a concise `CHANGELOG.md` entry under `Unreleased`. Use the `skip-changelog` PR label only for intentionally exempt maintenance changes.
+
 ## Public API Changes
 
-Any change to a public endpoint response shape, request shape, authentication behavior, or documented error behavior must include one of:
+Any structural public endpoint change must include all of:
 
-- a `CHANGELOG.md` entry,
-- a `.changeset/*.md` note, or
-- a `docs/release-policy.md` update when the policy itself changes.
+- a `CHANGELOG.md` entry under `Unreleased`,
+- documentation updates under `apps/docs/`,
+- OpenAPI source or generated contract updates under `src/openapi/` or `openapi/`.
+
+Structural endpoint changes include adding, removing, or renaming routes, HTTP methods, query/path/body parameters, filters, sort options, request validation, response fields, status codes, authentication behavior, pagination behavior, documented errors, or deprecations.
 
 Use PR labels to make intent visible:
 
@@ -24,7 +30,7 @@ Prefer additive changes first. For removals or incompatible behavior changes:
 - document the replacement,
 - keep the old route or field working when practical,
 - add deprecation notes before removing behavior,
-- update OpenAPI and contract snapshots in the same PR.
+- update `apps/docs/`, OpenAPI, and contract snapshots in the same PR.
 
 ## Versioning
 

--- a/scripts/check-release-policy.mjs
+++ b/scripts/check-release-policy.mjs
@@ -47,26 +47,26 @@ const policyRelevant = changed.filter((file) =>
     /^scripts\//,
     /^apps\/docs\//,
     /^openapi\//,
+    /^AGENTS\.md$/,
+    /^README\.md$/,
+    /^docs\/release-policy\.md$/,
     /^package\.json$/,
     /^pnpm-lock\.yaml$/,
     /^pnpm-workspace\.yaml$/,
+    /^\.coderabbit\.yaml$/,
+    /^\.github\/pull_request_template\.md$/,
     /^Dockerfile/,
     /^\.github\/workflows\//,
   ].some((pattern) => pattern.test(file)),
 );
 
-const hasReleaseNote = changed.some(
-  (file) =>
-    file === "CHANGELOG.md" ||
-    file === "docs/release-policy.md" ||
-    /^\.changeset\/.+\.md$/.test(file),
-);
+const hasReleaseNote = changed.includes("CHANGELOG.md");
 
 if (policyRelevant.length > 0 && !hasReleaseNote) {
   console.error(
     [
       "Release policy check failed.",
-      "Changes that can affect users or maintainers need a CHANGELOG.md update, docs/release-policy.md update, or .changeset/*.md note.",
+      "Changes that can affect users or maintainers need a CHANGELOG.md update under Unreleased.",
       "Relevant files:",
       ...policyRelevant.map((file) => `- ${file}`),
       "Use the skip-changelog PR label only for intentionally exempt maintenance changes.",


### PR DESCRIPTION
## Summary
- Added a repo-level `.coderabbit.yaml` to enforce review focus on public endpoint correctness, docs coverage, and `CHANGELOG.md` updates.
- Added path instructions for `src/routes`, OpenAPI files, `apps/docs`, and `CHANGELOG.md`.
- Added custom checks that fail PRs when structural API changes do not include both docs updates in `apps/docs/` and matching OpenAPI updates.
- Updated repo guidance, the release policy, and the PR template to make the documentation and changelog requirement explicit.

## Testing
- Validated the new CodeRabbit config against the live schema.
- Ran the release policy check successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository configuration to enforce changelog, docs, and OpenAPI sync for public endpoint changes; enabled automated review checks that block merges if requirements aren't met; turned on knowledge-base guidance and chat auto-reply.
* **Documentation**
  * Updated PR template, release policy, AGENTS.md, and CHANGELOG Unreleased to require Unreleased CHANGELOG entries and coordinated docs/OpenAPI updates; added verification steps and release-check guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egdata-app/egdata-api/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->