### PR TITLE
Add sandbox product hub GraphQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable public API, documentation, release, and sustainability changes shoul
 
 ## Unreleased
 
+- Added a GraphQL `sandboxHub` query that aggregates sandbox product data for user-facing product pages.
 - Added CodeRabbit configuration to enforce changelog updates and docs/OpenAPI coverage for public endpoint structure changes.
 - Tightened the release policy so user-facing and maintainer-facing changes require `CHANGELOG.md` entries.
 - Added an API-owned OpenAPI contract for the first public REST documentation slice.

--- a/src/graphql/resolvers/sandbox.ts
+++ b/src/graphql/resolvers/sandbox.ts
@@ -1,167 +1,621 @@
-import { Namespace, Item, Offer, Asset, AchievementSet, Build } from '../../models/index.js';
-import type { IResolvers } from '@graphql-tools/utils';
-import type { Context } from '../index.js';
-import { buildProjection } from '../../utils/projection.js';
-import { db } from '../../db/index.js';
-import { orderOffersObject } from '../../utils/order-offers-object.js';
-import { regions } from '../../utils/countries.js';
-import { ObjectId } from 'mongodb';
+import type { IResolvers } from "@graphql-tools/utils";
+import { ObjectId } from "mongodb";
+import { db } from "../../db/index.js";
+import {
+  AchievementSet,
+  Asset,
+  Build,
+  Item,
+  Namespace,
+  Offer,
+  PriceEngine,
+  Sandbox as SandboxModel,
+  Tags,
+} from "../../models/index.js";
+import { ageRatingsCountries } from "../../utils/age-ratings.js";
+import { regions } from "../../utils/countries.js";
+import { orderOffersObject } from "../../utils/order-offers-object.js";
+import type { Context } from "../index.js";
+
+type Document = Record<string, any>;
+
+const DEFAULT_COUNTRY = "US";
+const DEFAULT_OFFER_LIMIT = 8;
+const DEFAULT_UPDATE_LIMIT = 8;
+const MAX_OFFER_LIMIT = 24;
+const MAX_UPDATE_LIMIT = 24;
+
+const offerTypeRank: Record<string, number> = {
+  BASE_GAME: 0,
+  EDITION: 1,
+  BUNDLE: 2,
+  DLC: 3,
+  ADD_ON: 4,
+  ADDON: 4,
+  PASS: 5,
+  SEASON: 6,
+  DEMO: 7,
+};
+
+function clampLimit(value: number | undefined, fallback: number, max: number) {
+  if (!value || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(value, 1), max);
+}
+
+function resolveRegion(country: string | undefined) {
+  const selectedCountry = country || DEFAULT_COUNTRY;
+  return (
+    Object.keys(regions).find((region) =>
+      regions[region].countries.includes(selectedCountry),
+    ) || DEFAULT_COUNTRY
+  );
+}
+
+async function findPrimaryContent(sandboxId: string) {
+  const baseGameQuery = {
+    namespace: { $eq: sandboxId },
+    offerType: "BASE_GAME",
+    prePurchase: { $ne: true },
+    isCodeRedemptionOnly: false,
+  };
+
+  let offer = await Offer.findOne(baseGameQuery).lean();
+
+  if (!offer) {
+    offer = await Offer.findOne({
+      namespace: { $eq: sandboxId },
+      offerType: "BASE_GAME",
+      prePurchase: true,
+    }).lean();
+  }
+
+  if (offer) {
+    return { kind: "offer", offer, item: null };
+  }
+
+  const item = await Item.findOne({
+    namespace: { $eq: sandboxId },
+    entitlementType: "EXECUTABLE",
+    "releaseInfo.0": { $exists: true },
+  }).lean();
+
+  if (item) {
+    return { kind: "item", offer: null, item };
+  }
+
+  return { kind: "none", offer: null, item: null };
+}
+
+function collectAppIds(items: Document[]) {
+  return Array.from(
+    new Set(
+      items.flatMap((item) =>
+        (item.releaseInfo || [])
+          .map((releaseInfo: Document) => releaseInfo.appId)
+          .filter(Boolean),
+      ),
+    ),
+  );
+}
+
+function collectPlatforms(offer: Document | null, items: Document[]) {
+  const itemPlatforms = items.flatMap((item) =>
+    (item.releaseInfo || []).flatMap(
+      (releaseInfo: Document) => releaseInfo.platform || [],
+    ),
+  );
+  const offerPlatforms =
+    offer?.tags
+      ?.filter((tag: Document | null) => tag?.groupName === "platform")
+      .map((tag: Document) => tag.name)
+      .filter(Boolean) || [];
+
+  return Array.from(new Set([...itemPlatforms, ...offerPlatforms]));
+}
+
+async function collectGenres(offers: Document[]) {
+  const tagIds = Array.from(
+    new Set(
+      offers.flatMap((offer) =>
+        (offer.tags || [])
+          .map((tag: Document | null) => tag?.id)
+          .filter(Boolean),
+      ),
+    ),
+  );
+
+  if (tagIds.length === 0) {
+    return [];
+  }
+
+  return Tags.find({
+    id: { $in: tagIds },
+    groupName: "genre",
+  }).lean();
+}
+
+function sortFeaturedOffers(offers: Document[]) {
+  return [...offers].sort((a, b) => {
+    const rankA = offerTypeRank[a.offerType] ?? 99;
+    const rankB = offerTypeRank[b.offerType] ?? 99;
+
+    if (rankA !== rankB) {
+      return rankA - rankB;
+    }
+
+    const dateA = new Date(
+      a.releaseDate || a.effectiveDate || a.creationDate || 0,
+    ).getTime();
+    const dateB = new Date(
+      b.releaseDate || b.effectiveDate || b.creationDate || 0,
+    ).getTime();
+
+    return dateB - dateA;
+  });
+}
+
+function getAgeRating(sandbox: Document, country: string | undefined) {
+  if (!sandbox.ageGatings) {
+    return null;
+  }
+
+  const selectedCountry = country || DEFAULT_COUNTRY;
+  const selectedRating =
+    Object.entries(ageRatingsCountries).find(([, countries]) =>
+      countries.includes(selectedCountry),
+    )?.[0] ?? "Generic";
+
+  return (
+    sandbox.ageGatings[selectedRating] || sandbox.ageGatings.Generic || null
+  );
+}
+
+function getAchievementScore(achievement: Document) {
+  const score = Number(achievement.score ?? achievement.xp ?? 0);
+  return Number.isFinite(score) ? score : 0;
+}
+
+function summarizeAchievements(sets: Document[]) {
+  const achievements = sets.flatMap((set) => set.achievements || []);
+  const baseAchievements = sets
+    .filter((set) => set.isBase)
+    .flatMap((set) => set.achievements || []);
+
+  return {
+    sets: sets.length,
+    total: achievements.length,
+    baseTotal: baseAchievements.length,
+    xp: achievements.reduce(
+      (sum, achievement) => sum + getAchievementScore(achievement),
+      0,
+    ),
+  };
+}
+
+async function getSandboxStats(
+  sandboxId: string,
+  items: Document[],
+  achievements: Document[],
+) {
+  const [offers, assets] = await Promise.all([
+    Offer.countDocuments({ namespace: sandboxId }),
+    Asset.find({ namespace: sandboxId }).lean(),
+  ]);
+
+  const assetsMap = new Map(
+    assets.map((asset: Document) => [asset.artifactId, asset]),
+  );
+  let virtualAssetsCount = 0;
+
+  for (const item of items) {
+    for (const releaseInfo of item.releaseInfo || []) {
+      if (!assetsMap.has(releaseInfo.appId)) {
+        virtualAssetsCount += releaseInfo.platform?.length || 0;
+      }
+    }
+  }
+
+  const builds = await Build.countDocuments({
+    appName: {
+      $in: collectAppIds(items),
+    },
+  });
+
+  return {
+    offers,
+    items: items.length,
+    assets: assets.length + virtualAssetsCount,
+    builds,
+    achievements: achievements.flatMap(
+      (achievementSet) => achievementSet.achievements || [],
+    ).length,
+  };
+}
 
 const resolvers: IResolvers<any, Context> = {
-    Query: {
-        sandbox: async (_, { id }, context, info) => {
-            // Namespace model uses _id for namespace string
-            return Namespace.findOne({ _id: { $eq: id } }).lean();
-        },
-        sandboxes: async (_, { limit = 10, page = 1 }) => {
-            const skip = (page - 1) * limit;
-            const elements = await Namespace.find({}, undefined, { skip, limit }).lean();
-            return { elements, total: await Namespace.countDocuments(), page, limit };
-        }
+  Query: {
+    sandbox: async (_, { id }, context, info) => {
+      // Namespace model uses _id for namespace string
+      return Namespace.findOne({ _id: { $eq: id } }).lean();
     },
-    Sandbox: {
-        items: async (parent, { limit = 10, page = 1 }) => {
-            const skip = (page - 1) * limit;
-            const query = { namespace: parent._id };
-            const elements = await Item.find(query).sort({ lastModified: -1 }).skip(skip).limit(limit).lean();
-            return { elements, total: await Item.countDocuments(query), page, limit };
-        },
-        offers: async (parent, { limit = 10, page = 1 }) => {
-            const skip = (page - 1) * limit;
-            const query = { namespace: parent._id };
-            const elements = await Offer.find(query).sort({ lastModified: -1 }).skip(skip).limit(limit).lean();
-            return { elements: elements.map(orderOffersObject), total: await Offer.countDocuments(query), page, limit };
-        },
-        assets: async (parent, { limit = 10, page = 1, platform }) => {
-            const skip = (page - 1) * limit;
-            const sandboxId = parent._id;
+    sandboxHub: async (_, { id, country, offerLimit, updateLimit }) => {
+      const sandbox = await SandboxModel.findOne({ _id: { $eq: id } }).lean();
 
-            // Logic from src/routes/sandbox.ts
-            const items = await Item.find(
-                { namespace: sandboxId },
-                { id: 1, namespace: 1, releaseInfo: 1, title: 1 }
-            ).lean();
+      if (!sandbox) {
+        return null;
+      }
 
-            const realAssets = await Asset.find({ namespace: sandboxId }).sort({ updatedAt: -1 }).lean();
-            const realAssetsMap = new Map(realAssets.map((a: any) => [a.artifactId, a]));
+      const resolvedOfferLimit = clampLimit(
+        offerLimit,
+        DEFAULT_OFFER_LIMIT,
+        MAX_OFFER_LIMIT,
+      );
+      const resolvedUpdateLimit = clampLimit(
+        updateLimit,
+        DEFAULT_UPDATE_LIMIT,
+        MAX_UPDATE_LIMIT,
+      );
+      const region = resolveRegion(country);
+      const primary = await findPrimaryContent(id);
 
-            const virtualAssets = items.flatMap((item: any) =>
-                item.releaseInfo?.flatMap((releaseInfo: any) => {
-                    if (realAssetsMap.has(releaseInfo.appId)) return [];
-                    return releaseInfo.platform.map((p: string) => ({
-                        artifactId: releaseInfo.appId,
-                        downloadSizeBytes: 0,
-                        installedSizeBytes: 0,
-                        itemId: item.id,
-                        namespace: item.namespace,
-                        platform: p,
-                        _id: new ObjectId().toString(),
-                        title: item.title,
-                        updatedAt: new Date(0),
-                    }));
-                }) || []
-            );
+      const [items, achievements, rawOffers] = await Promise.all([
+        Item.find({ namespace: id }).lean(),
+        AchievementSet.find({ sandboxId: id }).lean(),
+        Offer.find({ namespace: id }, undefined, {
+          limit: Math.max(resolvedOfferLimit * 3, resolvedOfferLimit),
+          sort: { lastModifiedDate: -1 },
+        }).lean(),
+      ]);
 
-            let allAssets = [...realAssets, ...virtualAssets].sort((a: any, b: any) => {
-                const dateA = a.updatedAt || new Date(0);
-                const dateB = b.updatedAt || new Date(0);
-                return dateB.getTime() - dateA.getTime();
-            });
+      const appIds = collectAppIds(items);
+      const featuredOffers = sortFeaturedOffers(rawOffers).slice(
+        0,
+        resolvedOfferLimit,
+      );
 
-            if (platform) {
-                const platforms = platform.split(",");
-                allAssets = allAssets.filter((a: any) => platforms.includes(a.platform));
-            }
+      const [price, stats, recentBuilds, recentChanges, genres] =
+        await Promise.all([
+          primary.offer
+            ? PriceEngine.findOne({
+                offerId: { $eq: primary.offer.id },
+                region: { $eq: region },
+              }).lean()
+            : null,
+          getSandboxStats(id, items, achievements),
+          appIds.length > 0
+            ? Build.find({ appName: { $in: appIds } }, undefined, {
+                limit: resolvedUpdateLimit,
+                sort: { updatedAt: -1 },
+              }).lean()
+            : [],
+          db.db
+            .collection("changelogs_v2")
+            .find({
+              "metadata.contextId": {
+                $in: [
+                  id,
+                  ...rawOffers.map((offer: Document) => offer.id),
+                  ...items.map((item: Document) => item.id),
+                  ...appIds,
+                ],
+              },
+            })
+            .sort({ timestamp: -1 })
+            .limit(resolvedUpdateLimit)
+            .toArray(),
+          collectGenres(rawOffers),
+        ]);
 
-            const elements = allAssets.slice(skip, skip + limit);
+      const primaryOffer = (primary.offer ?? null) as Document | null;
+      const primaryItem = (primary.item ?? null) as Document | null;
+      const title =
+        primaryOffer?.title ||
+        primaryItem?.title ||
+        sandbox.displayName ||
+        sandbox.name ||
+        id;
+      const description =
+        primaryOffer?.description ||
+        primaryOffer?.longDescription ||
+        primaryItem?.description ||
+        sandbox.displayName ||
+        "";
 
-            return { elements, total: allAssets.length, page, limit, count: allAssets.length };
-        },
-        builds: async (parent, { limit = 10, page = 1, platform }) => {
-            const skip = (page - 1) * limit;
-            const items = await Item.find({ namespace: parent._id }, { releaseInfo: 1 }).lean();
-            const appIds = items.flatMap((i: any) => i.releaseInfo.map((r: any) => r.appId));
-            const query: any = { appName: { $in: appIds } };
-            // Platform filter for builds might need mapping appId to builds
-            const elements = await db.db.collection("builds").find(query).sort({ updatedAt: -1 }).skip(skip).limit(limit).toArray();
-            return { elements, total: await db.db.collection("builds").countDocuments(query), page, limit };
-        },
-        baseGame: async (parent, { country = 'US' }) => {
-            const region = Object.keys(regions).find(r => regions[r].countries.includes(country)) || 'US';
-            let baseGame = await Offer.findOne({ namespace: parent._id, offerType: "BASE_GAME", prePurchase: { $ne: true }, isCodeRedemptionOnly: false }).lean();
-            if (!baseGame) baseGame = await Offer.findOne({ namespace: parent._id, offerType: "BASE_GAME", prePurchase: true }).lean();
-            if (!baseGame) {
-                const executable = await Item.findOne({ namespace: parent._id, entitlementType: "EXECUTABLE", "releaseInfo.0": { $exists: true } }).lean();
-                return executable;
-            }
-            return orderOffersObject(baseGame);
-        },
-        achievements: async (parent, _, { loaders }) => {
-            return loaders.achievementSet.load(parent._id);
-        },
-        stats: async (parent) => {
-            const [offers, items, achievements, assets] = await Promise.all([
-                Offer.countDocuments({ namespace: parent._id }),
-                Item.find({ namespace: parent._id }).lean(),
-                AchievementSet.find({ sandboxId: parent._id }).lean(),
-                Asset.find({ namespace: parent._id }).lean()
-            ]);
-
-            const assetsMap = new Map(assets.map((a: any) => [a.artifactId, a]));
-            let virtualAssetsCount = 0;
-            for (const item of items as any[]) {
-                for (const releaseInfo of item.releaseInfo || []) {
-                    if (!assetsMap.has(releaseInfo.appId)) {
-                        virtualAssetsCount += releaseInfo.platform?.length || 0;
-                    }
-                }
-            }
-
-            return {
-                offers,
-                items: items.length,
-                assets: assets.length + virtualAssetsCount,
-                achievements: achievements.flatMap((a: any) => a.achievements || []).length
-            };
-        },
-        changelog: async (parent, { limit = 10, page = 1 }) => {
-            const skip = (page - 1) * limit;
-            const sandboxId = parent._id;
-
-            const offers = await db.db.collection("offers").find({ namespace: sandboxId }).sort({ lastModifiedDate: -1 }).limit(100).toArray();
-            const items = await Item.find({ $or: [{ id: { $in: offers.flatMap((o: any) => o.items.map((i: any) => i.id)) } }, { namespace: sandboxId }] }, { id: 1, releaseInfo: 1 }).limit(100).lean();
-            const assets = await Asset.find({ itemId: { $in: items.map((i: any) => i.id) } }).lean();
-            const buildAppIds = items.flatMap((i: any) => i.releaseInfo?.map((r: any) => r.appId) || []);
-            const builds = await db.db.collection("builds").find({ appName: { $in: buildAppIds } }).toArray();
-
-            const allIds = [
-                sandboxId,
-                ...offers.map((o: any) => o.id),
-                ...items.map((i: any) => i.id),
-                ...assets.map((a: any) => a.artifactId),
-                ...builds.map((b: any) => b._id.toString())
-            ];
-
-            const matchQuery = { "metadata.contextId": { $in: allIds } };
-            const totalCount = await db.db.collection("changelogs_v2").countDocuments(matchQuery);
-            const elements = await db.db.collection("changelogs_v2").find(matchQuery).sort({ timestamp: -1 }).skip(skip).limit(limit).toArray();
-
-            return {
-                elements,
-                totalCount,
-                totalPages: Math.ceil(totalCount / limit),
-                hasNextPage: page * limit < totalCount,
-                hasPreviousPage: page > 1
-            };
-        }
+      return {
+        id,
+        namespace: id,
+        title,
+        description,
+        primaryKind: primary.kind,
+        primaryOffer,
+        primaryItem,
+        sandbox,
+        price,
+        seller: primaryOffer?.seller ?? null,
+        developer:
+          primaryOffer?.developerDisplayName || primaryItem?.developer || null,
+        publisher: primaryOffer?.publisherDisplayName || null,
+        keyImages: primaryOffer?.keyImages || primaryItem?.keyImages || [],
+        genres,
+        platforms: collectPlatforms(primary.offer, items),
+        stats,
+        featuredOffers,
+        recentBuilds,
+        recentChanges,
+        ageRating: getAgeRating(sandbox, country),
+        achievements: summarizeAchievements(achievements),
+        created:
+          sandbox.created ||
+          sandbox.createdAt ||
+          primaryOffer?.creationDate ||
+          primaryItem?.creationDate,
+        updated:
+          sandbox.updated ||
+          sandbox.updatedAt ||
+          primaryOffer?.lastModifiedDate ||
+          primaryItem?.lastModifiedDate,
+      };
     },
-    BaseGameResult: {
-        __resolveType(obj: any) {
-            if (obj.offerType) return 'Offer';
-            if (obj.entitlementName) return 'Item';
-            return null;
+    sandboxes: async (_, { limit = 10, page = 1 }) => {
+      const skip = (page - 1) * limit;
+      const elements = await Namespace.find({}, undefined, {
+        skip,
+        limit,
+      }).lean();
+      return { elements, total: await Namespace.countDocuments(), page, limit };
+    },
+  },
+  Sandbox: {
+    items: async (parent, { limit = 10, page = 1 }) => {
+      const skip = (page - 1) * limit;
+      const query = { namespace: parent._id };
+      const elements = await Item.find(query)
+        .sort({ lastModified: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return { elements, total: await Item.countDocuments(query), page, limit };
+    },
+    offers: async (parent, { limit = 10, page = 1 }) => {
+      const skip = (page - 1) * limit;
+      const query = { namespace: parent._id };
+      const elements = await Offer.find(query)
+        .sort({ lastModified: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        elements: elements.map(orderOffersObject),
+        total: await Offer.countDocuments(query),
+        page,
+        limit,
+      };
+    },
+    assets: async (parent, { limit = 10, page = 1, platform }) => {
+      const skip = (page - 1) * limit;
+      const sandboxId = parent._id;
+
+      // Logic from src/routes/sandbox.ts
+      const items = await Item.find(
+        { namespace: sandboxId },
+        { id: 1, namespace: 1, releaseInfo: 1, title: 1 },
+      ).lean();
+
+      const realAssets = await Asset.find({ namespace: sandboxId })
+        .sort({ updatedAt: -1 })
+        .lean();
+      const realAssetsMap = new Map(
+        realAssets.map((a: any) => [a.artifactId, a]),
+      );
+
+      const virtualAssets = items.flatMap(
+        (item: any) =>
+          item.releaseInfo?.flatMap((releaseInfo: any) => {
+            if (realAssetsMap.has(releaseInfo.appId)) return [];
+            return (releaseInfo.platform || []).map((p: string) => ({
+              artifactId: releaseInfo.appId,
+              downloadSizeBytes: 0,
+              installedSizeBytes: 0,
+              itemId: item.id,
+              namespace: item.namespace,
+              platform: p,
+              _id: new ObjectId().toString(),
+              title: item.title,
+              updatedAt: new Date(0),
+            }));
+          }) || [],
+      );
+
+      let allAssets = [...realAssets, ...virtualAssets].sort(
+        (a: any, b: any) => {
+          const dateA = a.updatedAt || new Date(0);
+          const dateB = b.updatedAt || new Date(0);
+          return dateB.getTime() - dateA.getTime();
+        },
+      );
+
+      if (platform) {
+        const platforms = platform.split(",");
+        allAssets = allAssets.filter((a: any) =>
+          platforms.includes(a.platform),
+        );
+      }
+
+      const elements = allAssets.slice(skip, skip + limit);
+
+      return {
+        elements,
+        total: allAssets.length,
+        page,
+        limit,
+        count: allAssets.length,
+      };
+    },
+    builds: async (parent, { limit = 10, page = 1, platform }) => {
+      const skip = (page - 1) * limit;
+      const items = await Item.find(
+        { namespace: parent._id },
+        { releaseInfo: 1 },
+      ).lean();
+      const appIds = items.flatMap((i: any) =>
+        (i.releaseInfo || []).map((r: any) => r.appId),
+      );
+      const query: any = { appName: { $in: appIds } };
+      // Platform filter for builds might need mapping appId to builds
+      const elements = await db.db
+        .collection("builds")
+        .find(query)
+        .sort({ updatedAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray();
+      return {
+        elements,
+        total: await db.db.collection("builds").countDocuments(query),
+        page,
+        limit,
+      };
+    },
+    baseGame: async (parent, { country = "US" }) => {
+      const region =
+        Object.keys(regions).find((r) =>
+          regions[r].countries.includes(country),
+        ) || "US";
+      let baseGame = await Offer.findOne({
+        namespace: parent._id,
+        offerType: "BASE_GAME",
+        prePurchase: { $ne: true },
+        isCodeRedemptionOnly: false,
+      }).lean();
+      if (!baseGame)
+        baseGame = await Offer.findOne({
+          namespace: parent._id,
+          offerType: "BASE_GAME",
+          prePurchase: true,
+        }).lean();
+      if (!baseGame) {
+        const executable = await Item.findOne({
+          namespace: parent._id,
+          entitlementType: "EXECUTABLE",
+          "releaseInfo.0": { $exists: true },
+        }).lean();
+        return executable;
+      }
+      return orderOffersObject(baseGame);
+    },
+    achievements: async (parent, _, { loaders }) => {
+      return loaders.achievementSet.load(parent._id);
+    },
+    stats: async (parent) => {
+      const [offers, items, achievements, assets] = await Promise.all([
+        Offer.countDocuments({ namespace: parent._id }),
+        Item.find({ namespace: parent._id }).lean(),
+        AchievementSet.find({ sandboxId: parent._id }).lean(),
+        Asset.find({ namespace: parent._id }).lean(),
+      ]);
+
+      const assetsMap = new Map(assets.map((a: any) => [a.artifactId, a]));
+      let virtualAssetsCount = 0;
+      for (const item of items as any[]) {
+        for (const releaseInfo of item.releaseInfo || []) {
+          if (!assetsMap.has(releaseInfo.appId)) {
+            virtualAssetsCount += releaseInfo.platform?.length || 0;
+          }
         }
-    }
+      }
+
+      const builds = await Build.countDocuments({
+        appName: {
+          $in: items.flatMap((i: any) =>
+            (i.releaseInfo || []).map((r: any) => r.appId),
+          ),
+        },
+      });
+
+      return {
+        offers,
+        items: items.length,
+        assets: assets.length + virtualAssetsCount,
+        builds,
+        achievements: achievements.flatMap((a: any) => a.achievements || [])
+          .length,
+      };
+    },
+    changelog: async (parent, { limit = 10, page = 1 }) => {
+      const skip = (page - 1) * limit;
+      const sandboxId = parent._id;
+
+      const offers = await db.db
+        .collection("offers")
+        .find({ namespace: sandboxId })
+        .sort({ lastModifiedDate: -1 })
+        .limit(100)
+        .toArray();
+      const items = await Item.find(
+        {
+          $or: [
+            {
+              id: {
+                $in: offers.flatMap((o: any) => o.items.map((i: any) => i.id)),
+              },
+            },
+            { namespace: sandboxId },
+          ],
+        },
+        { id: 1, releaseInfo: 1 },
+      )
+        .limit(100)
+        .lean();
+      const assets = await Asset.find({
+        itemId: { $in: items.map((i: any) => i.id) },
+      }).lean();
+      const buildAppIds = items.flatMap(
+        (i: any) => i.releaseInfo?.map((r: any) => r.appId) || [],
+      );
+      const builds = await db.db
+        .collection("builds")
+        .find({ appName: { $in: buildAppIds } })
+        .toArray();
+
+      const allIds = [
+        sandboxId,
+        ...offers.map((o: any) => o.id),
+        ...items.map((i: any) => i.id),
+        ...assets.map((a: any) => a.artifactId),
+        ...builds.map((b: any) => b._id.toString()),
+      ];
+
+      const matchQuery = { "metadata.contextId": { $in: allIds } };
+      const totalCount = await db.db
+        .collection("changelogs_v2")
+        .countDocuments(matchQuery);
+      const elements = await db.db
+        .collection("changelogs_v2")
+        .find(matchQuery)
+        .sort({ timestamp: -1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray();
+
+      return {
+        elements,
+        totalCount,
+        totalPages: Math.ceil(totalCount / limit),
+        hasNextPage: page * limit < totalCount,
+        hasPreviousPage: page > 1,
+      };
+    },
+  },
+  BaseGameResult: {
+    __resolveType(obj: any) {
+      if (obj.offerType) return "Offer";
+      if (obj.entitlementName) return "Item";
+      return null;
+    },
+  },
 };
 
 export default resolvers;

--- a/src/graphql/resolvers/sandbox.ts
+++ b/src/graphql/resolvers/sandbox.ts
@@ -15,6 +15,7 @@ import {
 } from "../../models/index.js";
 import { ageRatingsCountries } from "../../utils/age-ratings.js";
 import { regions } from "../../utils/countries.js";
+import { consola } from "../../utils/logger.js";
 import { orderOffersObject } from "../../utils/order-offers-object.js";
 import type { Context } from "../index.js";
 
@@ -25,6 +26,9 @@ const DEFAULT_OFFER_LIMIT = 8;
 const DEFAULT_UPDATE_LIMIT = 8;
 const MAX_OFFER_LIMIT = 24;
 const MAX_UPDATE_LIMIT = 24;
+const DEFAULT_PAGE_LIMIT = 10;
+const MAX_PAGE_LIMIT = 100;
+const MAX_PAGE = 10_000;
 const SANDBOX_HUB_CACHE_TTL_SECONDS = 3600;
 
 const offerTypeRank: Record<string, number> = {
@@ -45,6 +49,26 @@ function clampLimit(value: number | undefined, fallback: number, max: number) {
   }
 
   return Math.min(Math.max(value, 1), max);
+}
+
+function clampPage(value: number | undefined) {
+  return clampLimit(value, 1, MAX_PAGE);
+}
+
+function resolvePagination(
+  limit: number | undefined,
+  page: number | undefined,
+  fallbackLimit = DEFAULT_PAGE_LIMIT,
+  maxLimit = MAX_PAGE_LIMIT,
+) {
+  const resolvedLimit = clampLimit(limit, fallbackLimit, maxLimit);
+  const resolvedPage = clampPage(page);
+
+  return {
+    limit: resolvedLimit,
+    page: resolvedPage,
+    skip: (resolvedPage - 1) * resolvedLimit,
+  };
 }
 
 function resolveRegion(country: string | undefined) {
@@ -279,7 +303,14 @@ const resolvers: IResolvers<any, Context> = {
       const cached = await client.get(cacheKey);
 
       if (cached) {
-        return JSON.parse(cached);
+        try {
+          return JSON.parse(cached);
+        } catch (error) {
+          consola.warn("Ignoring malformed sandboxHub cache payload", {
+            cacheKey,
+            error,
+          });
+        }
       }
 
       const sandbox = await SandboxModel.findOne({ _id: { $eq: id } }).lean();
@@ -405,42 +436,52 @@ const resolvers: IResolvers<any, Context> = {
       return hub;
     },
     sandboxes: async (_, { limit = 10, page = 1 }) => {
-      const skip = (page - 1) * limit;
+      const pagination = resolvePagination(limit, page);
       const elements = await Namespace.find({}, undefined, {
-        skip,
-        limit,
+        skip: pagination.skip,
+        limit: pagination.limit,
       }).lean();
-      return { elements, total: await Namespace.countDocuments(), page, limit };
+      return {
+        elements,
+        total: await Namespace.countDocuments(),
+        page: pagination.page,
+        limit: pagination.limit,
+      };
     },
   },
   Sandbox: {
     items: async (parent, { limit = 10, page = 1 }) => {
-      const skip = (page - 1) * limit;
+      const pagination = resolvePagination(limit, page);
       const query = { namespace: parent._id };
       const elements = await Item.find(query)
         .sort({ lastModifiedDate: -1 })
-        .skip(skip)
-        .limit(limit)
+        .skip(pagination.skip)
+        .limit(pagination.limit)
         .lean();
-      return { elements, total: await Item.countDocuments(query), page, limit };
+      return {
+        elements,
+        total: await Item.countDocuments(query),
+        page: pagination.page,
+        limit: pagination.limit,
+      };
     },
     offers: async (parent, { limit = 10, page = 1 }) => {
-      const skip = (page - 1) * limit;
+      const pagination = resolvePagination(limit, page);
       const query = { namespace: parent._id };
       const elements = await Offer.find(query)
         .sort({ lastModifiedDate: -1 })
-        .skip(skip)
-        .limit(limit)
+        .skip(pagination.skip)
+        .limit(pagination.limit)
         .lean();
       return {
         elements: elements.map(orderOffersObject),
         total: await Offer.countDocuments(query),
-        page,
-        limit,
+        page: pagination.page,
+        limit: pagination.limit,
       };
     },
     assets: async (parent, { limit = 10, page = 1, platform }) => {
-      const skip = (page - 1) * limit;
+      const pagination = resolvePagination(limit, page);
       const sandboxId = parent._id;
 
       // Logic from src/routes/sandbox.ts
@@ -489,18 +530,21 @@ const resolvers: IResolvers<any, Context> = {
         );
       }
 
-      const elements = allAssets.slice(skip, skip + limit);
+      const elements = allAssets.slice(
+        pagination.skip,
+        pagination.skip + pagination.limit,
+      );
 
       return {
         elements,
         total: allAssets.length,
-        page,
-        limit,
+        page: pagination.page,
+        limit: pagination.limit,
         count: allAssets.length,
       };
     },
     builds: async (parent, { limit = 10, page = 1, platform }) => {
-      const skip = (page - 1) * limit;
+      const pagination = resolvePagination(limit, page);
       const platforms = platform?.split(",").filter(Boolean) ?? [];
       const itemQuery: Document = { namespace: parent._id };
 
@@ -525,14 +569,14 @@ const resolvers: IResolvers<any, Context> = {
         .collection("builds")
         .find(query)
         .sort({ updatedAt: -1 })
-        .skip(skip)
-        .limit(limit)
+        .skip(pagination.skip)
+        .limit(pagination.limit)
         .toArray();
       return {
         elements,
         total: await db.db.collection("builds").countDocuments(query),
-        page,
-        limit,
+        page: pagination.page,
+        limit: pagination.limit,
       };
     },
     baseGame: async (parent) => {
@@ -573,7 +617,7 @@ const resolvers: IResolvers<any, Context> = {
       };
     },
     changelog: async (parent, { limit = 10, page = 1 }) => {
-      const skip = (page - 1) * limit;
+      const pagination = resolvePagination(limit, page);
       const sandboxId = parent._id;
 
       const offers = await db.db
@@ -624,16 +668,16 @@ const resolvers: IResolvers<any, Context> = {
         .collection("changelogs_v2")
         .find(matchQuery)
         .sort({ timestamp: -1 })
-        .skip(skip)
-        .limit(limit)
+        .skip(pagination.skip)
+        .limit(pagination.limit)
         .toArray();
 
       return {
         elements,
         totalCount,
-        totalPages: Math.ceil(totalCount / limit),
-        hasNextPage: page * limit < totalCount,
-        hasPreviousPage: page > 1,
+        totalPages: Math.ceil(totalCount / pagination.limit),
+        hasNextPage: pagination.page * pagination.limit < totalCount,
+        hasPreviousPage: pagination.page > 1,
       };
     },
   },

--- a/src/graphql/resolvers/sandbox.ts
+++ b/src/graphql/resolvers/sandbox.ts
@@ -1,5 +1,6 @@
 import type { IResolvers } from "@graphql-tools/utils";
 import { ObjectId } from "mongodb";
+import client from "../../clients/redis.js";
 import { db } from "../../db/index.js";
 import {
   AchievementSet,
@@ -24,6 +25,7 @@ const DEFAULT_OFFER_LIMIT = 8;
 const DEFAULT_UPDATE_LIMIT = 8;
 const MAX_OFFER_LIMIT = 24;
 const MAX_UPDATE_LIMIT = 24;
+const SANDBOX_HUB_CACHE_TTL_SECONDS = 3600;
 
 const offerTypeRank: Record<string, number> = {
   BASE_GAME: 0,
@@ -52,6 +54,15 @@ function resolveRegion(country: string | undefined) {
       regions[region].countries.includes(selectedCountry),
     ) || DEFAULT_COUNTRY
   );
+}
+
+function createSandboxHubCacheKey(
+  id: string,
+  country: string,
+  offerLimit: number,
+  updateLimit: number,
+) {
+  return `sandboxHub:${id}:${country}:${offerLimit}:${updateLimit}`;
 }
 
 async function findPrimaryContent(sandboxId: string) {
@@ -242,12 +253,6 @@ const resolvers: IResolvers<any, Context> = {
       return Namespace.findOne({ _id: { $eq: id } }).lean();
     },
     sandboxHub: async (_, { id, country, offerLimit, updateLimit }) => {
-      const sandbox = await SandboxModel.findOne({ _id: { $eq: id } }).lean();
-
-      if (!sandbox) {
-        return null;
-      }
-
       const resolvedOfferLimit = clampLimit(
         offerLimit,
         DEFAULT_OFFER_LIMIT,
@@ -258,14 +263,39 @@ const resolvers: IResolvers<any, Context> = {
         DEFAULT_UPDATE_LIMIT,
         MAX_UPDATE_LIMIT,
       );
-      const region = resolveRegion(country);
+      const selectedCountry = country || DEFAULT_COUNTRY;
+      const cacheKey = createSandboxHubCacheKey(
+        id,
+        selectedCountry,
+        resolvedOfferLimit,
+        resolvedUpdateLimit,
+      );
+      const cached = await client.get(cacheKey);
+
+      if (cached) {
+        return JSON.parse(cached);
+      }
+
+      const sandbox = await SandboxModel.findOne({ _id: { $eq: id } }).lean();
+
+      if (!sandbox) {
+        await client.set(
+          cacheKey,
+          JSON.stringify(null),
+          "EX",
+          SANDBOX_HUB_CACHE_TTL_SECONDS,
+        );
+        return null;
+      }
+
+      const region = resolveRegion(selectedCountry);
       const primary = await findPrimaryContent(id);
 
       const [items, achievements, rawOffers] = await Promise.all([
         Item.find({ namespace: id }).lean(),
         AchievementSet.find({ sandboxId: id }).lean(),
         Offer.find({ namespace: id }, undefined, {
-          limit: Math.max(resolvedOfferLimit * 3, resolvedOfferLimit),
+          limit: resolvedOfferLimit * 3,
           sort: { lastModifiedDate: -1 },
         }).lean(),
       ]);
@@ -324,7 +354,7 @@ const resolvers: IResolvers<any, Context> = {
         sandbox.displayName ||
         "";
 
-      return {
+      const hub = {
         id,
         namespace: id,
         title,
@@ -345,7 +375,7 @@ const resolvers: IResolvers<any, Context> = {
         featuredOffers,
         recentBuilds,
         recentChanges,
-        ageRating: getAgeRating(sandbox, country),
+        ageRating: getAgeRating(sandbox, selectedCountry),
         achievements: summarizeAchievements(achievements),
         created:
           sandbox.created ||
@@ -358,6 +388,15 @@ const resolvers: IResolvers<any, Context> = {
           primaryOffer?.lastModifiedDate ||
           primaryItem?.lastModifiedDate,
       };
+
+      await client.set(
+        cacheKey,
+        JSON.stringify(hub),
+        "EX",
+        SANDBOX_HUB_CACHE_TTL_SECONDS,
+      );
+
+      return hub;
     },
     sandboxes: async (_, { limit = 10, page = 1 }) => {
       const skip = (page - 1) * limit;
@@ -373,7 +412,7 @@ const resolvers: IResolvers<any, Context> = {
       const skip = (page - 1) * limit;
       const query = { namespace: parent._id };
       const elements = await Item.find(query)
-        .sort({ lastModified: -1 })
+        .sort({ lastModifiedDate: -1 })
         .skip(skip)
         .limit(limit)
         .lean();
@@ -383,7 +422,7 @@ const resolvers: IResolvers<any, Context> = {
       const skip = (page - 1) * limit;
       const query = { namespace: parent._id };
       const elements = await Offer.find(query)
-        .sort({ lastModified: -1 })
+        .sort({ lastModifiedDate: -1 })
         .skip(skip)
         .limit(limit)
         .lean();
@@ -456,15 +495,26 @@ const resolvers: IResolvers<any, Context> = {
     },
     builds: async (parent, { limit = 10, page = 1, platform }) => {
       const skip = (page - 1) * limit;
-      const items = await Item.find(
-        { namespace: parent._id },
-        { releaseInfo: 1 },
-      ).lean();
+      const platforms = platform?.split(",").filter(Boolean) ?? [];
+      const itemQuery: Document = { namespace: parent._id };
+
+      if (platforms.length > 0) {
+        itemQuery.releaseInfo = {
+          $elemMatch: { platform: { $in: platforms } },
+        };
+      }
+
+      const items = await Item.find(itemQuery, { releaseInfo: 1 }).lean();
       const appIds = items.flatMap((i: any) =>
-        (i.releaseInfo || []).map((r: any) => r.appId),
+        (i.releaseInfo || [])
+          .filter(
+            (r: any) =>
+              platforms.length === 0 ||
+              (r.platform || []).some((p: string) => platforms.includes(p)),
+          )
+          .map((r: any) => r.appId),
       );
       const query: any = { appName: { $in: appIds } };
-      // Platform filter for builds might need mapping appId to builds
       const elements = await db.db
         .collection("builds")
         .find(query)
@@ -479,32 +529,14 @@ const resolvers: IResolvers<any, Context> = {
         limit,
       };
     },
-    baseGame: async (parent, { country = "US" }) => {
-      const region =
-        Object.keys(regions).find((r) =>
-          regions[r].countries.includes(country),
-        ) || "US";
-      let baseGame = await Offer.findOne({
-        namespace: parent._id,
-        offerType: "BASE_GAME",
-        prePurchase: { $ne: true },
-        isCodeRedemptionOnly: false,
-      }).lean();
-      if (!baseGame)
-        baseGame = await Offer.findOne({
-          namespace: parent._id,
-          offerType: "BASE_GAME",
-          prePurchase: true,
-        }).lean();
-      if (!baseGame) {
-        const executable = await Item.findOne({
-          namespace: parent._id,
-          entitlementType: "EXECUTABLE",
-          "releaseInfo.0": { $exists: true },
-        }).lean();
-        return executable;
+    baseGame: async (parent) => {
+      const primary = await findPrimaryContent(parent._id);
+
+      if (primary.offer) {
+        return orderOffersObject(primary.offer);
       }
-      return orderOffersObject(baseGame);
+
+      return primary.item;
     },
     achievements: async (parent, _, { loaders }) => {
       return loaders.achievementSet.load(parent._id);

--- a/src/graphql/resolvers/sandbox.ts
+++ b/src/graphql/resolvers/sandbox.ts
@@ -556,15 +556,17 @@ const resolvers: IResolvers<any, Context> = {
       }
 
       const items = await Item.find(itemQuery, { releaseInfo: 1 }).lean();
-      const appIds = items.flatMap((i: any) =>
-        (i.releaseInfo || [])
-          .filter(
-            (r: any) =>
-              platforms.length === 0 ||
-              (r.platform || []).some((p: string) => platforms.includes(p)),
-          )
-          .map((r: any) => r.appId),
-      );
+      const appIds = items
+        .flatMap((i: any) =>
+          (i.releaseInfo || [])
+            .filter(
+              (r: any) =>
+                platforms.length === 0 ||
+                (r.platform || []).some((p: string) => platforms.includes(p)),
+            )
+            .map((r: any) => r.appId),
+        )
+        .filter(Boolean);
       const query: any = { appName: { $in: appIds } };
       const elements = await db.db
         .collection("builds")

--- a/src/graphql/resolvers/sandbox.ts
+++ b/src/graphql/resolvers/sandbox.ts
@@ -206,6 +206,23 @@ function summarizeAchievements(sets: Document[]) {
   };
 }
 
+function countVirtualAssets(items: Document[], assets: Document[]) {
+  const assetArtifactIds = new Set(
+    assets.map((asset: Document) => asset.artifactId),
+  );
+  let virtualAssetsCount = 0;
+
+  for (const item of items) {
+    for (const releaseInfo of item.releaseInfo || []) {
+      if (!assetArtifactIds.has(releaseInfo.appId)) {
+        virtualAssetsCount += releaseInfo.platform?.length || 0;
+      }
+    }
+  }
+
+  return virtualAssetsCount;
+}
+
 async function getSandboxStats(
   sandboxId: string,
   items: Document[],
@@ -216,18 +233,7 @@ async function getSandboxStats(
     Asset.find({ namespace: sandboxId }).lean(),
   ]);
 
-  const assetsMap = new Map(
-    assets.map((asset: Document) => [asset.artifactId, asset]),
-  );
-  let virtualAssetsCount = 0;
-
-  for (const item of items) {
-    for (const releaseInfo of item.releaseInfo || []) {
-      if (!assetsMap.has(releaseInfo.appId)) {
-        virtualAssetsCount += releaseInfo.platform?.length || 0;
-      }
-    }
-  }
+  const virtualAssetsCount = countVirtualAssets(items, assets);
 
   const builds = await Build.countDocuments({
     appName: {
@@ -549,21 +555,11 @@ const resolvers: IResolvers<any, Context> = {
         Asset.find({ namespace: parent._id }).lean(),
       ]);
 
-      const assetsMap = new Map(assets.map((a: any) => [a.artifactId, a]));
-      let virtualAssetsCount = 0;
-      for (const item of items as any[]) {
-        for (const releaseInfo of item.releaseInfo || []) {
-          if (!assetsMap.has(releaseInfo.appId)) {
-            virtualAssetsCount += releaseInfo.platform?.length || 0;
-          }
-        }
-      }
+      const virtualAssetsCount = countVirtualAssets(items, assets);
 
       const builds = await Build.countDocuments({
         appName: {
-          $in: items.flatMap((i: any) =>
-            (i.releaseInfo || []).map((r: any) => r.appId),
-          ),
+          $in: collectAppIds(items),
         },
       });
 

--- a/src/graphql/resolvers/sandbox.ts
+++ b/src/graphql/resolvers/sandbox.ts
@@ -29,6 +29,7 @@ const MAX_UPDATE_LIMIT = 24;
 const DEFAULT_PAGE_LIMIT = 10;
 const MAX_PAGE_LIMIT = 100;
 const MAX_PAGE = 10_000;
+const CHANGELOG_BUILD_CONTEXT_LIMIT = 500;
 const SANDBOX_HUB_CACHE_TTL_SECONDS = 3600;
 
 const offerTypeRank: Record<string, number> = {
@@ -631,7 +632,9 @@ const resolvers: IResolvers<any, Context> = {
           $or: [
             {
               id: {
-                $in: offers.flatMap((o: any) => o.items.map((i: any) => i.id)),
+                $in: offers.flatMap((o: any) =>
+                  (o.items ?? []).map((i: any) => i.id),
+                ),
               },
             },
             { namespace: sandboxId },
@@ -650,6 +653,8 @@ const resolvers: IResolvers<any, Context> = {
       const builds = await db.db
         .collection("builds")
         .find({ appName: { $in: buildAppIds } })
+        .sort({ updatedAt: -1 })
+        .limit(CHANGELOG_BUILD_CONTEXT_LIMIT)
         .toArray();
 
       const allIds = [

--- a/src/graphql/typedefs.ts
+++ b/src/graphql/typedefs.ts
@@ -18,6 +18,7 @@ export const typeDefs = `#graphql
 
         # Sandboxes
         sandbox(id: ID!): Sandbox
+        sandboxHub(id: ID!, country: String, offerLimit: Int, updateLimit: Int): SandboxHub
         sandboxes(limit: Int, page: Int): SandboxConnection
 
         # Misc
@@ -243,9 +244,13 @@ export const typeDefs = `#graphql
     type Sandbox {
         _id: ID
         name: String
+        displayName: String
         namespace: String
         parent: String
+        store: String
+        status: String
         ageGatings: JSON
+        created: Date
         updated: Date
         items(limit: Int, page: Int): ItemConnection
         offers(limit: Int, page: Int): OfferConnection
@@ -255,6 +260,39 @@ export const typeDefs = `#graphql
         achievements: [AchievementSet]
         stats: SandboxStats
         changelog(limit: Int, page: Int): ChangelogConnection
+    }
+
+    type SandboxHub {
+        id: ID
+        namespace: String
+        title: String
+        description: String
+        primaryKind: String
+        primaryOffer: Offer
+        primaryItem: Item
+        sandbox: Sandbox
+        price: Price
+        seller: Seller
+        developer: String
+        publisher: String
+        keyImages: [KeyImage]
+        genres: [Tag]
+        platforms: [String]
+        stats: SandboxStats
+        featuredOffers: [Offer]
+        recentBuilds: [Build]
+        recentChanges: [Changelog]
+        ageRating: JSON
+        achievements: SandboxAchievementSummary
+        created: Date
+        updated: Date
+    }
+
+    type SandboxAchievementSummary {
+        sets: Int
+        total: Int
+        baseTotal: Int
+        xp: Int
     }
 
     type AssetConnection {

--- a/tests/sandbox-hub-resolver.test.ts
+++ b/tests/sandbox-hub-resolver.test.ts
@@ -34,6 +34,13 @@ type SandboxHubResolver = (
   info: unknown,
 ) => Promise<SandboxHubResult | null>;
 
+type OfferFindOneQuery = {
+  isCodeRedemptionOnly?: boolean;
+  namespace?: { $eq?: string } | string;
+  offerType?: string;
+  prePurchase?: boolean | { $ne?: boolean };
+};
+
 const mocks = vi.hoisted(() => ({
   achievementSetFind: vi.fn(),
   assetFind: vi.fn(),
@@ -46,6 +53,8 @@ const mocks = vi.hoisted(() => ({
   offerFind: vi.fn(),
   offerFindOne: vi.fn(),
   priceFindOne: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
   sandboxFindOne: vi.fn(),
   tagsFind: vi.fn(),
 }));
@@ -91,6 +100,13 @@ vi.mock("../src/models/index.js", () => ({
   },
   Tags: {
     find: mocks.tagsFind,
+  },
+}));
+
+vi.mock("../src/clients/redis.js", () => ({
+  default: {
+    get: mocks.redisGet,
+    set: mocks.redisSet,
   },
 }));
 
@@ -205,6 +221,45 @@ function mockRecentChanges(changes: unknown[]) {
   });
 }
 
+function isReleasedBaseGameQuery(query: OfferFindOneQuery) {
+  return (
+    query.namespace &&
+    typeof query.namespace === "object" &&
+    query.namespace.$eq === "sandbox-1" &&
+    query.offerType === "BASE_GAME" &&
+    typeof query.prePurchase === "object" &&
+    query.prePurchase.$ne === true &&
+    query.isCodeRedemptionOnly === false
+  );
+}
+
+function isPrepurchaseBaseGameQuery(query: OfferFindOneQuery) {
+  return (
+    query.namespace &&
+    typeof query.namespace === "object" &&
+    query.namespace.$eq === "sandbox-1" &&
+    query.offerType === "BASE_GAME" &&
+    query.prePurchase === true
+  );
+}
+
+function mockPrimaryOffers(
+  releasedBaseGame: typeof baseOffer | null,
+  prepurchaseBaseGame: typeof baseOffer | null,
+) {
+  mocks.offerFindOne.mockImplementation((query: OfferFindOneQuery) => {
+    if (isReleasedBaseGameQuery(query)) {
+      return lean(releasedBaseGame);
+    }
+
+    if (isPrepurchaseBaseGameQuery(query)) {
+      return lean(prepurchaseBaseGame);
+    }
+
+    throw new Error(`Unexpected Offer.findOne query: ${JSON.stringify(query)}`);
+  });
+}
+
 async function sandboxHub(args: Record<string, unknown> = {}) {
   const resolver = (sandboxResolvers.Query as Record<string, unknown>)
     .sandboxHub as SandboxHubResolver;
@@ -230,10 +285,10 @@ async function requireSandboxHub(args: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
 
+  mocks.redisGet.mockResolvedValue(null);
+  mocks.redisSet.mockResolvedValue("OK");
   mocks.sandboxFindOne.mockReturnValue(lean(sandbox));
-  mocks.offerFindOne.mockImplementation((query) =>
-    lean(query.prePurchase === true ? null : baseOffer),
-  );
+  mockPrimaryOffers(baseOffer, null);
   mocks.itemFindOne.mockReturnValue(lean(null));
   mocks.itemFind.mockReturnValue(chain([executableItem]));
   mocks.achievementSetFind.mockReturnValue(
@@ -282,6 +337,33 @@ beforeEach(() => {
 });
 
 describe("sandboxHub GraphQL resolver", () => {
+  it("returns cached hub data before running database work", async () => {
+    const cachedHub: SandboxHubResult = {
+      achievements: {},
+      ageRating: null,
+      description: "Cached description",
+      developer: null,
+      featuredOffers: [],
+      id: "sandbox-1",
+      platforms: [],
+      price: null,
+      primaryItem: null,
+      primaryKind: "offer",
+      primaryOffer: null,
+      publisher: null,
+      recentBuilds: [],
+      recentChanges: [],
+      stats: {},
+      title: "Cached Hub",
+    };
+    mocks.redisGet.mockResolvedValue(JSON.stringify(cachedHub));
+
+    await expect(sandboxHub()).resolves.toEqual(cachedHub);
+    expect(mocks.redisGet).toHaveBeenCalledWith("sandboxHub:sandbox-1:US:4:3");
+    expect(mocks.sandboxFindOne).not.toHaveBeenCalled();
+    expect(mocks.offerFindOne).not.toHaveBeenCalled();
+  });
+
   it("uses a non-prepurchase base game as the primary product", async () => {
     const hub = await requireSandboxHub();
 
@@ -320,9 +402,7 @@ describe("sandboxHub GraphQL resolver", () => {
   });
 
   it("falls back to a prepurchase base game when no released base game exists", async () => {
-    mocks.offerFindOne.mockImplementation((query) =>
-      lean(query.prePurchase === true ? prepurchaseOffer : null),
-    );
+    mockPrimaryOffers(null, prepurchaseOffer);
     mocks.priceFindOne.mockReturnValue(
       lean({
         offerId: "prepurchase-offer",
@@ -344,7 +424,7 @@ describe("sandboxHub GraphQL resolver", () => {
   });
 
   it("falls back to an executable item when no base game offer exists", async () => {
-    mocks.offerFindOne.mockReturnValue(lean(null));
+    mockPrimaryOffers(null, null);
     mocks.itemFindOne.mockReturnValue(lean(executableItem));
 
     const hub = await requireSandboxHub();
@@ -357,7 +437,7 @@ describe("sandboxHub GraphQL resolver", () => {
   });
 
   it("returns a sparse hub for an empty sandbox", async () => {
-    mocks.offerFindOne.mockReturnValue(lean(null));
+    mockPrimaryOffers(null, null);
     mocks.itemFindOne.mockReturnValue(lean(null));
     mocks.itemFind.mockReturnValue(chain([]));
     mocks.achievementSetFind.mockReturnValue(chain([]));
@@ -385,6 +465,9 @@ describe("sandboxHub GraphQL resolver", () => {
         achievements: 0,
       },
     });
+    expect(hub.price).toBeNull();
+    expect(hub.primaryOffer).toBeNull();
+    expect(hub.primaryItem).toBeNull();
   });
 
   it("returns null for a missing sandbox", async () => {
@@ -393,5 +476,7 @@ describe("sandboxHub GraphQL resolver", () => {
     await expect(sandboxHub()).resolves.toBeNull();
     expect(mocks.offerFindOne).not.toHaveBeenCalled();
     expect(mocks.itemFind).not.toHaveBeenCalled();
+    expect(mocks.itemFindOne).not.toHaveBeenCalled();
+    expect(mocks.priceFindOne).not.toHaveBeenCalled();
   });
 });

--- a/tests/sandbox-hub-resolver.test.ts
+++ b/tests/sandbox-hub-resolver.test.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import sandboxResolvers from "../src/graphql/resolvers/sandbox.js";
+
+type QueryLike = {
+  lean: ReturnType<typeof vi.fn>;
+  sort?: ReturnType<typeof vi.fn>;
+  skip?: ReturnType<typeof vi.fn>;
+  limit?: ReturnType<typeof vi.fn>;
+};
+
+type SandboxHubResult = {
+  achievements: unknown;
+  ageRating: unknown;
+  description: string;
+  developer: string | null;
+  featuredOffers: Array<{ id: string }>;
+  id: string;
+  platforms: string[];
+  price: unknown | null;
+  primaryItem: { id: string } | null;
+  primaryKind: string;
+  primaryOffer: { id: string } | null;
+  publisher: string | null;
+  recentBuilds: unknown[];
+  recentChanges: unknown[];
+  stats: unknown;
+  title: string;
+};
+
+type SandboxHubResolver = (
+  parent: unknown,
+  args: Record<string, unknown>,
+  context: unknown,
+  info: unknown,
+) => Promise<SandboxHubResult | null>;
+
+const mocks = vi.hoisted(() => ({
+  achievementSetFind: vi.fn(),
+  assetFind: vi.fn(),
+  buildCountDocuments: vi.fn(),
+  buildFind: vi.fn(),
+  collection: vi.fn(),
+  itemFind: vi.fn(),
+  itemFindOne: vi.fn(),
+  offerCountDocuments: vi.fn(),
+  offerFind: vi.fn(),
+  offerFindOne: vi.fn(),
+  priceFindOne: vi.fn(),
+  sandboxFindOne: vi.fn(),
+  tagsFind: vi.fn(),
+}));
+
+vi.mock("../src/db/index.js", () => ({
+  db: {
+    db: {
+      collection: mocks.collection,
+    },
+  },
+}));
+
+vi.mock("../src/models/index.js", () => ({
+  AchievementSet: {
+    find: mocks.achievementSetFind,
+  },
+  Asset: {
+    find: mocks.assetFind,
+  },
+  Build: {
+    countDocuments: mocks.buildCountDocuments,
+    find: mocks.buildFind,
+  },
+  Item: {
+    find: mocks.itemFind,
+    findOne: mocks.itemFindOne,
+  },
+  Namespace: {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    countDocuments: vi.fn(),
+  },
+  Offer: {
+    countDocuments: mocks.offerCountDocuments,
+    find: mocks.offerFind,
+    findOne: mocks.offerFindOne,
+  },
+  PriceEngine: {
+    findOne: mocks.priceFindOne,
+  },
+  Sandbox: {
+    findOne: mocks.sandboxFindOne,
+  },
+  Tags: {
+    find: mocks.tagsFind,
+  },
+}));
+
+vi.mock("../src/utils/age-ratings.js", () => ({
+  ageRatingsCountries: {
+    ESRB: ["US"],
+    PEGI: ["ES"],
+  },
+}));
+
+vi.mock("../src/utils/countries.js", () => ({
+  regions: {
+    EURO: { countries: ["ES", "FR"] },
+    US: { countries: ["US"] },
+  },
+}));
+
+const sandbox = {
+  _id: "sandbox-1",
+  displayName: "Fallback Sandbox Name",
+  name: "Fallback Namespace Name",
+  ageGatings: {
+    ESRB: { rating: "Teen" },
+    Generic: { rating: "General" },
+  },
+  created: "2024-01-01T00:00:00.000Z",
+  updated: "2024-02-01T00:00:00.000Z",
+};
+
+const baseOffer = {
+  _id: "base-offer-object",
+  id: "base-offer",
+  namespace: "sandbox-1",
+  title: "Base Game",
+  description: "Base game description",
+  offerType: "BASE_GAME",
+  seller: { id: "seller-1", name: "Seller" },
+  developerDisplayName: "Developer",
+  publisherDisplayName: "Publisher",
+  prePurchase: false,
+  keyImages: [{ type: "OfferImageWide", url: "https://example.test/base.jpg" }],
+  tags: [{ id: "genre-action", name: "Action", groupName: "genre" }],
+  releaseDate: "2024-03-01T00:00:00.000Z",
+  creationDate: "2024-01-10T00:00:00.000Z",
+  lastModifiedDate: "2024-03-02T00:00:00.000Z",
+  customAttributes: [{ key: "CanRunOffline", type: "STRING", value: "true" }],
+  items: [{ id: "item-1", namespace: "sandbox-1" }],
+};
+
+const prepurchaseOffer = {
+  ...baseOffer,
+  id: "prepurchase-offer",
+  title: "Future Base Game",
+  prePurchase: true,
+};
+
+const executableItem = {
+  _id: "item-object",
+  id: "item-1",
+  namespace: "sandbox-1",
+  title: "Executable Item",
+  description: "Executable item description",
+  entitlementType: "EXECUTABLE",
+  developer: "Item Developer",
+  keyImages: [{ type: "OfferImageWide", url: "https://example.test/item.jpg" }],
+  creationDate: "2024-01-05T00:00:00.000Z",
+  lastModifiedDate: "2024-02-05T00:00:00.000Z",
+  releaseInfo: [{ appId: "app-1", platform: ["Windows"] }],
+};
+
+const featuredDlc = {
+  ...baseOffer,
+  id: "dlc-offer",
+  title: "DLC",
+  offerType: "DLC",
+  releaseDate: "2024-04-01T00:00:00.000Z",
+};
+
+function lean<T>(value: T): QueryLike {
+  return {
+    lean: vi.fn().mockResolvedValue(value),
+  };
+}
+
+function chain<T>(value: T): QueryLike {
+  const query: QueryLike = {
+    lean: vi.fn().mockResolvedValue(value),
+    limit: vi.fn(),
+    skip: vi.fn(),
+    sort: vi.fn(),
+  };
+
+  query.limit?.mockReturnValue(query);
+  query.skip?.mockReturnValue(query);
+  query.sort?.mockReturnValue(query);
+
+  return query;
+}
+
+function mockRecentChanges(changes: unknown[]) {
+  const query = {
+    sort: vi.fn(),
+    limit: vi.fn(),
+    toArray: vi.fn().mockResolvedValue(changes),
+  };
+
+  query.sort.mockReturnValue(query);
+  query.limit.mockReturnValue(query);
+
+  mocks.collection.mockReturnValue({
+    find: vi.fn().mockReturnValue(query),
+  });
+}
+
+async function sandboxHub(args: Record<string, unknown> = {}) {
+  const resolver = (sandboxResolvers.Query as Record<string, unknown>)
+    .sandboxHub as SandboxHubResolver;
+
+  return resolver(
+    null,
+    { id: "sandbox-1", country: "US", offerLimit: 4, updateLimit: 3, ...args },
+    {},
+    {},
+  );
+}
+
+async function requireSandboxHub(args: Record<string, unknown> = {}) {
+  const hub = await sandboxHub(args);
+
+  if (!hub) {
+    throw new Error("Expected sandboxHub to return hub data");
+  }
+
+  return hub;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.sandboxFindOne.mockReturnValue(lean(sandbox));
+  mocks.offerFindOne.mockImplementation((query) =>
+    lean(query.prePurchase === true ? null : baseOffer),
+  );
+  mocks.itemFindOne.mockReturnValue(lean(null));
+  mocks.itemFind.mockReturnValue(chain([executableItem]));
+  mocks.achievementSetFind.mockReturnValue(
+    chain([
+      {
+        sandboxId: "sandbox-1",
+        isBase: true,
+        achievements: [
+          { id: "ach-1", score: 10 },
+          { id: "ach-2", score: 15 },
+        ],
+      },
+    ]),
+  );
+  mocks.offerFind.mockReturnValue(chain([featuredDlc, baseOffer]));
+  mocks.offerCountDocuments.mockResolvedValue(2);
+  mocks.assetFind.mockReturnValue(chain([]));
+  mocks.buildCountDocuments.mockResolvedValue(1);
+  mocks.buildFind.mockReturnValue(
+    chain([
+      {
+        _id: "build-1",
+        appName: "app-1",
+        labelName: "Live",
+        updatedAt: "2024-05-01T00:00:00.000Z",
+      },
+    ]),
+  );
+  mocks.priceFindOne.mockReturnValue(
+    lean({
+      offerId: "base-offer",
+      region: "US",
+      price: { currencyCode: "USD", discountPrice: 1999, originalPrice: 1999 },
+    }),
+  );
+  mocks.tagsFind.mockReturnValue(
+    chain([{ id: "genre-action", name: "Action", groupName: "genre" }]),
+  );
+  mockRecentChanges([
+    {
+      _id: "change-1",
+      metadata: { contextId: "base-offer", contextType: "Offer", changes: [] },
+      timestamp: "2024-05-02T00:00:00.000Z",
+    },
+  ]);
+});
+
+describe("sandboxHub GraphQL resolver", () => {
+  it("uses a non-prepurchase base game as the primary product", async () => {
+    const hub = await requireSandboxHub();
+
+    expect(hub).toMatchObject({
+      id: "sandbox-1",
+      primaryKind: "offer",
+      title: "Base Game",
+      description: "Base game description",
+      developer: "Developer",
+      publisher: "Publisher",
+      price: {
+        offerId: "base-offer",
+        region: "US",
+      },
+      ageRating: { rating: "Teen" },
+      stats: {
+        offers: 2,
+        items: 1,
+        assets: 1,
+        builds: 1,
+        achievements: 2,
+      },
+      achievements: {
+        sets: 1,
+        total: 2,
+        baseTotal: 2,
+        xp: 25,
+      },
+    });
+    expect(hub.featuredOffers.map((offer) => offer.id)).toEqual([
+      "base-offer",
+      "dlc-offer",
+    ]);
+    expect(hub.recentBuilds).toHaveLength(1);
+    expect(hub.recentChanges).toHaveLength(1);
+  });
+
+  it("falls back to a prepurchase base game when no released base game exists", async () => {
+    mocks.offerFindOne.mockImplementation((query) =>
+      lean(query.prePurchase === true ? prepurchaseOffer : null),
+    );
+    mocks.priceFindOne.mockReturnValue(
+      lean({
+        offerId: "prepurchase-offer",
+        region: "US",
+        price: {
+          currencyCode: "USD",
+          discountPrice: 4999,
+          originalPrice: 4999,
+        },
+      }),
+    );
+
+    const hub = await requireSandboxHub();
+
+    expect(hub.primaryKind).toBe("offer");
+    expect(hub.primaryOffer?.id).toBe("prepurchase-offer");
+    expect(hub.title).toBe("Future Base Game");
+    expect(mocks.itemFindOne).not.toHaveBeenCalled();
+  });
+
+  it("falls back to an executable item when no base game offer exists", async () => {
+    mocks.offerFindOne.mockReturnValue(lean(null));
+    mocks.itemFindOne.mockReturnValue(lean(executableItem));
+
+    const hub = await requireSandboxHub();
+
+    expect(hub.primaryKind).toBe("item");
+    expect(hub.primaryItem?.id).toBe("item-1");
+    expect(hub.title).toBe("Executable Item");
+    expect(hub.price).toBeNull();
+    expect(hub.platforms).toEqual(["Windows"]);
+  });
+
+  it("returns a sparse hub for an empty sandbox", async () => {
+    mocks.offerFindOne.mockReturnValue(lean(null));
+    mocks.itemFindOne.mockReturnValue(lean(null));
+    mocks.itemFind.mockReturnValue(chain([]));
+    mocks.achievementSetFind.mockReturnValue(chain([]));
+    mocks.offerFind.mockReturnValue(chain([]));
+    mocks.offerCountDocuments.mockResolvedValue(0);
+    mocks.assetFind.mockReturnValue(chain([]));
+    mocks.buildCountDocuments.mockResolvedValue(0);
+    mocks.tagsFind.mockReturnValue(chain([]));
+    mockRecentChanges([]);
+
+    const hub = await requireSandboxHub();
+
+    expect(hub).toMatchObject({
+      primaryKind: "none",
+      title: "Fallback Sandbox Name",
+      description: "Fallback Sandbox Name",
+      featuredOffers: [],
+      recentBuilds: [],
+      recentChanges: [],
+      stats: {
+        offers: 0,
+        items: 0,
+        assets: 0,
+        builds: 0,
+        achievements: 0,
+      },
+    });
+  });
+
+  it("returns null for a missing sandbox", async () => {
+    mocks.sandboxFindOne.mockReturnValue(lean(null));
+
+    await expect(sandboxHub()).resolves.toBeNull();
+    expect(mocks.offerFindOne).not.toHaveBeenCalled();
+    expect(mocks.itemFind).not.toHaveBeenCalled();
+  });
+});

--- a/tests/sandbox-hub-resolver.test.ts
+++ b/tests/sandbox-hub-resolver.test.ts
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
   offerFind: vi.fn(),
   offerFindOne: vi.fn(),
   priceFindOne: vi.fn(),
+  loggerWarn: vi.fn(),
   redisGet: vi.fn(),
   redisSet: vi.fn(),
   sandboxFindOne: vi.fn(),
@@ -107,6 +108,12 @@ vi.mock("../src/clients/redis.js", () => ({
   default: {
     get: mocks.redisGet,
     set: mocks.redisSet,
+  },
+}));
+
+vi.mock("../src/utils/logger.js", () => ({
+  consola: {
+    warn: mocks.loggerWarn,
   },
 }));
 
@@ -362,6 +369,19 @@ describe("sandboxHub GraphQL resolver", () => {
     expect(mocks.redisGet).toHaveBeenCalledWith("sandboxHub:sandbox-1:US:4:3");
     expect(mocks.sandboxFindOne).not.toHaveBeenCalled();
     expect(mocks.offerFindOne).not.toHaveBeenCalled();
+  });
+
+  it("recomputes hub data when cached hub data is malformed", async () => {
+    mocks.redisGet.mockResolvedValue("{malformed");
+
+    const hub = await requireSandboxHub();
+
+    expect(hub.title).toBe("Base Game");
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "Ignoring malformed sandboxHub cache payload",
+      expect.objectContaining({ cacheKey: "sandboxHub:sandbox-1:US:4:3" }),
+    );
+    expect(mocks.sandboxFindOne).toHaveBeenCalled();
   });
 
   it("uses a non-prepurchase base game as the primary product", async () => {


### PR DESCRIPTION
## Summary


## API / Docs Checklist

- [ ] `CHANGELOG.md` updated under `Unreleased` for this change.
- [ ] Public endpoint structure changed: `apps/docs/` updated.
- [ ] Public endpoint structure changed: OpenAPI updated with request, response, auth, and visibility metadata.
- [ ] Contract snapshots or route coverage updated when public routes changed.
- [ ] Not applicable: this PR has no public API or docs impact.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GraphQL sandbox hub query that returns an aggregated sandbox payload (primary content selection, regional pricing, featured/recent content, platforms, genres, stats, age ratings, achievements, timestamps, and pagination/sorting for items/offers/assets).

* **Schema**
  * Introduced SandboxHub and related fields to the GraphQL schema.

* **Tests**
  * Added tests covering hub behavior: caching, malformed-cache handling, selection fallbacks, ordering, sparse/empty cases, and edge conditions.

* **Documentation**
  * Updated changelog with the new sandbox hub entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egdata-app/egdata-api/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->