### PR TITLE
Add GraphQL profile showcase fields and resolver support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable public API, documentation, release, and sustainability changes shoul
 
 ## Unreleased
 
+- Added a public GraphQL `profile(id)` query for profile identity, highlights, featured games, achievements, and recent activity.
 - Added a GraphQL `sandboxHub` query that aggregates sandbox product data for user-facing product pages.
 - Added CodeRabbit configuration to enforce changelog updates and docs/OpenAPI coverage for public endpoint structure changes.
 - Tightened the release policy so user-facing and maintainer-facing changes require `CHANGELOG.md` entries.

--- a/apps/docs/content/docs/graphql-profiles.mdx
+++ b/apps/docs/content/docs/graphql-profiles.mdx
@@ -1,0 +1,61 @@
+---
+title: GraphQL Profiles
+description: Fetch public profile showcase data with field-level GraphQL selection.
+---
+
+The GraphQL endpoint is available at:
+
+```txt
+https://api.egdata.app/graphql
+```
+
+Use `profile(id: ID!)` to fetch public player identity, showcase highlights, featured games, rare achievements, and recent activity without calling multiple REST profile routes.
+
+```graphql
+query ProfileShowcase($id: ID!) {
+  profile(id: $id) {
+    accountId
+    displayName
+    avatar {
+      large
+    }
+    highlights {
+      level
+      totalXP
+      totalGames
+      totalAchievements
+      totalPlatinums
+      reviewsCount
+    }
+    heroGame {
+      sandboxId
+      title
+      imageUrl
+      completionPercent
+    }
+    featuredGames(limit: 6, filter: ALL, sort: COMPLETION) {
+      sandboxId
+      title
+      imageUrl
+      completionPercent
+      earnedXP
+      totalXP
+      hasPlatinum
+      rarestAchievements {
+        displayName
+        iconUrl
+        rarityPercent
+      }
+    }
+    recentActivity(limit: 8) {
+      type
+      gameTitle
+      achievementName
+      achievementIconUrl
+      occurredAt
+    }
+  }
+}
+```
+
+`profile` returns `null` when the Epic profile is unavailable. Profiles with no imported achievement data return empty game, achievement, and activity lists.

--- a/apps/docs/content/docs/graphql-profiles.mdx
+++ b/apps/docs/content/docs/graphql-profiles.mdx
@@ -9,7 +9,56 @@ The GraphQL endpoint is available at:
 https://api.egdata.app/graphql
 ```
 
-Use `profile(id: ID!)` to fetch public player identity, showcase highlights, featured games, rare achievements, and recent activity without calling multiple REST profile routes.
+Use `profile(id: ID!)` to fetch public player identity, showcase highlights, featured games, rare achievements, and recent activity without calling multiple REST profile routes. The query is public: it does not require an `Authorization` header, bearer token, or token scopes.
+
+## Arguments
+
+`profile` accepts the Epic account id as `id`.
+
+| Argument | Type | Required | Behavior |
+| --- | --- | --- | --- |
+| `id` | `ID!` | Yes | Epic account id to resolve. Returns `null` when the Epic profile cannot be found or is unavailable. |
+
+Profile list fields accept these arguments:
+
+| Field | Arguments | Defaults | Maximum `limit` |
+| --- | --- | --- | --- |
+| `featuredAchievements` | `limit` | `limit: 8` | `100` |
+| `featuredGames` | `limit`, `filter`, `sort` | `limit: 6`, `filter: ALL`, `sort: COMPLETION` | `100` |
+| `recentActivity` | `limit`, `page` | `limit: 12`, `page: 1` | `100` |
+| `games` | `limit`, `page`, `filter`, `sort` | `limit: 12`, `page: 1`, `filter: ALL`, `sort: COMPLETION` | `100` |
+| `achievements` | `limit`, `page` | `limit: 25`, `page: 1` | `100` |
+
+Pagination uses 1-based `page` values. `page: 2` returns the next `limit` results after page 1. Non-positive `page` values are normalized to the first page, and large `limit` values are capped at `100`.
+
+## Game Filters
+
+`featuredGames` and `games` support the same `filter` values:
+
+| Value | Meaning |
+| --- | --- |
+| `ALL` | All games with imported achievement data. |
+| `COMPLETED` | Games where every achievement is unlocked. |
+| `NEAR_PLATINUM` | Games at high completion that are not complete or platinumed yet. |
+| `IN_PROGRESS` | Games with at least one unlock and less than full completion. |
+| `PLATINUM` | Games with a platinum/player award. |
+
+## Game Sorts
+
+`featuredGames` and `games` support the same `sort` values:
+
+| Value | Meaning |
+| --- | --- |
+| `COMPLETION` | Highest completion first, then XP and unlock count. |
+| `ALPHABETICAL` | Game title ascending. |
+| `XP` | Highest earned XP first. |
+| `ACHIEVEMENTS` | Highest unlocked achievement count first. |
+
+`completionPercent` is returned from `0` to `100`. `level` is calculated as `Math.floor(totalXP / 250)`, and profile `totalXP` includes earned achievement XP plus `250` XP for each platinum/player award.
+
+`recentActivity` currently returns only `ACHIEVEMENT_UNLOCKED` and `PLATINUM_EARNED` items because those records have reliable timestamps.
+
+## Showcase Query
 
 ```graphql
 query ProfileShowcase($id: ID!) {
@@ -19,6 +68,9 @@ query ProfileShowcase($id: ID!) {
     avatar {
       large
     }
+    linkedAccounts
+    creationDate
+    reviewsCount
     highlights {
       level
       totalXP
@@ -32,6 +84,19 @@ query ProfileShowcase($id: ID!) {
       title
       imageUrl
       completionPercent
+      earnedXP
+      totalXP
+      hasPlatinum
+    }
+    featuredAchievements(limit: 8) {
+      displayName
+      description
+      iconUrl
+      rarityPercent
+      xp
+      sandboxId
+      gameTitle
+      unlockedAt
     }
     featuredGames(limit: 6, filter: ALL, sort: COMPLETION) {
       sandboxId
@@ -47,8 +112,9 @@ query ProfileShowcase($id: ID!) {
         rarityPercent
       }
     }
-    recentActivity(limit: 8) {
+    recentActivity(limit: 8, page: 1) {
       type
+      sandboxId
       gameTitle
       achievementName
       achievementIconUrl
@@ -58,4 +124,48 @@ query ProfileShowcase($id: ID!) {
 }
 ```
 
-`profile` returns `null` when the Epic profile is unavailable. Profiles with no imported achievement data return empty game, achievement, and activity lists.
+## Library Query
+
+Use the `games` and `achievements` connections when a page needs paginated library data.
+
+```graphql
+query ProfileLibrary($id: ID!, $page: Int!) {
+  profile(id: $id) {
+    games(limit: 12, page: $page, filter: IN_PROGRESS, sort: ALPHABETICAL) {
+      total
+      page
+      limit
+      elements {
+        sandboxId
+        title
+        completionPercent
+        unlocked
+        total
+        earnedXP
+        totalXP
+        hasPlatinum
+      }
+    }
+    achievements(limit: 25, page: $page) {
+      total
+      page
+      limit
+      elements {
+        displayName
+        iconUrl
+        rarityPercent
+        xp
+        sandboxId
+        gameTitle
+        unlockedAt
+      }
+    }
+  }
+}
+```
+
+## Errors
+
+`profile` returns `null` when the Epic profile lookup fails. Profiles with no imported achievement data return empty game, achievement, and activity lists.
+
+Invalid GraphQL documents, missing required variables, or invalid enum values such as an unknown `filter` or `sort` return standard GraphQL errors. The `profile` query itself is public, so `401` and `403` responses are not expected for valid profile requests. Clients may still receive `429` if platform rate limits are exceeded, or `5xx` responses for unexpected upstream or server failures.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -3,6 +3,7 @@
     "---Guides---",
     "index",
     "authentication",
+    "graphql-profiles",
     "regions-pagination-errors",
     "changelog-deprecations",
     "---API Reference---",

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -5,6 +5,7 @@ import items from "./resolvers/item.js";
 import builds from "./resolvers/build.js";
 import changelogs from "./resolvers/changelog.js";
 import sandboxes from "./resolvers/sandbox.js";
+import profiles from "./resolvers/profile.js";
 import type { ConsolaInstance } from "consola";
 import { GraphQLDateTime, GraphQLJSON } from 'graphql-scalars';
 import { createLoaders } from './loaders.js';
@@ -22,7 +23,7 @@ export type Context = {
 
 export const server = new ApolloServer<Context>({
     typeDefs,
-    resolvers: [offers, items, builds, changelogs, sandboxes, resolvers],
+    resolvers: [offers, items, builds, changelogs, sandboxes, profiles, resolvers],
     introspection: true,
     plugins: [
         {

--- a/src/graphql/resolvers/profile.ts
+++ b/src/graphql/resolvers/profile.ts
@@ -1,0 +1,101 @@
+import type { IResolvers } from "@graphql-tools/utils";
+import type { Context } from "../index.js";
+import {
+  getFeaturedAchievements,
+  getFeaturedGames,
+  getProfileAchievementConnection,
+  getProfileGameConnection,
+  getProfileHeroGame,
+  getProfileHighlights,
+  getProfileIdentity,
+  getRecentActivity,
+  type ProfileIdentity,
+  type ProfileRequestCache,
+} from "../services/profile.js";
+
+type ProfileContext = Context & {
+  profileRequestCache?: ProfileRequestCache;
+};
+
+function getProfileRequestCache(context: ProfileContext) {
+  context.profileRequestCache ??= new Map<string, Promise<unknown>>();
+  return context.profileRequestCache;
+}
+
+const resolvers: IResolvers<Record<string, unknown>, Context> = {
+  Query: {
+    profile: async (_, { id }, context) => {
+      return getProfileIdentity(id, getProfileRequestCache(context));
+    },
+  },
+  Profile: {
+    highlights: async (parent: ProfileIdentity, _, context) => {
+      return getProfileHighlights(
+        parent.accountId,
+        parent.reviewsCount,
+        getProfileRequestCache(context),
+      );
+    },
+    heroGame: async (parent: ProfileIdentity, _, context) => {
+      return getProfileHeroGame(
+        parent.accountId,
+        getProfileRequestCache(context),
+      );
+    },
+    featuredAchievements: async (
+      parent: ProfileIdentity,
+      { limit },
+      context,
+    ) => {
+      return getFeaturedAchievements(
+        parent.accountId,
+        limit,
+        getProfileRequestCache(context),
+      );
+    },
+    featuredGames: async (
+      parent: ProfileIdentity,
+      { filter, limit, sort },
+      context,
+    ) => {
+      return getFeaturedGames(
+        parent.accountId,
+        { filter, limit, sort },
+        getProfileRequestCache(context),
+      );
+    },
+    recentActivity: async (
+      parent: ProfileIdentity,
+      { limit, page },
+      context,
+    ) => {
+      return getRecentActivity(
+        parent.accountId,
+        limit,
+        page,
+        getProfileRequestCache(context),
+      );
+    },
+    games: async (
+      parent: ProfileIdentity,
+      { filter, limit, page, sort },
+      context,
+    ) => {
+      return getProfileGameConnection(
+        parent.accountId,
+        { filter, limit, page, sort },
+        getProfileRequestCache(context),
+      );
+    },
+    achievements: async (parent: ProfileIdentity, { limit, page }, context) => {
+      return getProfileAchievementConnection(
+        parent.accountId,
+        limit,
+        page,
+        getProfileRequestCache(context),
+      );
+    },
+  },
+};
+
+export default resolvers;

--- a/src/graphql/services/profile.ts
+++ b/src/graphql/services/profile.ts
@@ -1,0 +1,946 @@
+import { epicStoreClient } from "../../clients/epic.js";
+import client from "../../clients/redis.js";
+import { db } from "../../db/index.js";
+import { AchievementSet, Offer, Review } from "../../models/index.js";
+import { getImage } from "../../utils/get-image.js";
+
+type Document = Record<string, any>;
+
+export type ProfileRequestCache = Map<string, Promise<unknown>>;
+
+export type ProfileGameFilter =
+  | "ALL"
+  | "COMPLETED"
+  | "NEAR_PLATINUM"
+  | "IN_PROGRESS"
+  | "PLATINUM";
+
+export type ProfileGameSort =
+  | "COMPLETION"
+  | "ALPHABETICAL"
+  | "XP"
+  | "ACHIEVEMENTS";
+
+export type ProfileIdentity = {
+  accountId: string;
+  displayName: string | null;
+  avatar: {
+    small: string | null;
+    medium: string | null;
+    large: string | null;
+  };
+  linkedAccounts: Document | null;
+  creationDate: string | Date | null;
+  reviewsCount: number;
+};
+
+export type ProfileHighlights = {
+  level: number;
+  totalXP: number;
+  totalGames: number;
+  totalAchievements: number;
+  totalPlatinums: number;
+  reviewsCount: number;
+};
+
+export type ProfileAchievement = {
+  name: string;
+  displayName: string;
+  description: string | null;
+  iconUrl: string | null;
+  rarityPercent: number;
+  xp: number;
+  sandboxId: string;
+  gameTitle: string;
+  unlockedAt: string | Date | null;
+};
+
+export type ProfileGame = {
+  sandboxId: string;
+  title: string;
+  imageUrl: string | null;
+  completionPercent: number;
+  unlocked: number;
+  total: number;
+  earnedXP: number;
+  totalXP: number;
+  hasPlatinum: boolean;
+  platinumCount: number;
+  rarestAchievements: ProfileAchievement[];
+};
+
+export type ProfileActivityItem = {
+  type: "ACHIEVEMENT_UNLOCKED" | "PLATINUM_EARNED";
+  sandboxId: string;
+  gameTitle: string;
+  achievementName: string | null;
+  achievementIconUrl: string | null;
+  occurredAt: string | Date;
+};
+
+export type ProfileGameConnection = {
+  elements: ProfileGame[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type ProfileAchievementConnection = {
+  elements: ProfileAchievement[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+type PlayerAchievementRow = {
+  playerAchievement?: {
+    achievementName?: string;
+    achievementSetId?: string;
+    sandboxId?: string;
+    unlocked?: boolean;
+    unlockDate?: string | Date | null;
+    XP?: number;
+  };
+};
+
+type NormalizedPlayerGame = {
+  sandboxId: string;
+  totalUnlocked: number;
+  totalXP: number;
+  playerAwards: Document[];
+  playerAchievements: PlayerAchievementRow[];
+};
+
+type ProfileAggregationData = {
+  games: ProfileGame[];
+  achievements: ProfileAchievement[];
+  activity: ProfileActivityItem[];
+};
+
+const PROFILE_CACHE_VERSION = "v1";
+const PROFILE_IDENTITY_TTL_SECONDS = 3600;
+const PROFILE_HIGHLIGHTS_TTL_SECONDS = 300;
+const PROFILE_GAMES_TTL_SECONDS = 60;
+const PROFILE_ACHIEVEMENTS_TTL_SECONDS = 3600;
+const PROFILE_ACTIVITY_TTL_SECONDS = 60;
+const DEFAULT_LIMIT = 12;
+const DEFAULT_ACHIEVEMENT_LIMIT = 25;
+const MAX_LIMIT = 100;
+const PLATINUM_XP = 250;
+
+const GAME_IMAGE_TYPES: Parameters<typeof getImage>[1] = [
+  "DieselStoreFrontWide",
+  "OfferImageWide",
+  "Thumbnail",
+  "DieselGameBoxWide",
+  "DieselStoreFrontTall",
+  "OfferImageTall",
+];
+
+function clampLimit(value: number | undefined, fallback: number) {
+  if (!value || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_LIMIT);
+}
+
+function clampPage(value: number | undefined) {
+  if (!value || Number.isNaN(value)) {
+    return 1;
+  }
+
+  return Math.max(Math.trunc(value), 1);
+}
+
+function roundPercent(value: number) {
+  const clamped = Math.min(Math.max(value, 0), 100);
+  return Number(clamped.toFixed(2));
+}
+
+function normalizeRarityPercent(value: unknown) {
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric)) {
+    return 100;
+  }
+
+  const percentage = numeric > 0 && numeric <= 1 ? numeric * 100 : numeric;
+  return roundPercent(percentage);
+}
+
+function toTime(value: string | Date | null | undefined) {
+  if (!value) {
+    return 0;
+  }
+
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+function latestDate(
+  a: string | Date | null | undefined,
+  b: string | Date | null | undefined,
+) {
+  return toTime(a) >= toTime(b) ? a : b;
+}
+
+function stableAwardKey(award: Document) {
+  return [
+    award.awardType ?? "",
+    award.achievementSetId ?? "",
+    award.unlockedDateTime ?? "",
+  ].join(":");
+}
+
+function stableAchievementKey(row: PlayerAchievementRow) {
+  const achievement = row.playerAchievement ?? {};
+  return [
+    achievement.sandboxId ?? "",
+    achievement.achievementSetId ?? "",
+    achievement.achievementName ?? "",
+  ].join(":");
+}
+
+function getAchievementXP(achievement: Document) {
+  const xp = Number(achievement.xp ?? achievement.XP ?? achievement.score ?? 0);
+  return Number.isFinite(xp) ? xp : 0;
+}
+
+function getAchievementIconUrl(achievement: Document) {
+  return (
+    achievement.unlockedIcon ??
+    achievement.lockedIcon ??
+    achievement.iconUrl ??
+    achievement.icon ??
+    null
+  );
+}
+
+function getAchievementDisplayName(achievement: Document) {
+  return (
+    achievement.displayName ??
+    achievement.title ??
+    achievement.name ??
+    "Unknown achievement"
+  );
+}
+
+function getGameTitle(offer: Document | null | undefined, sandboxId: string) {
+  return offer?.title ?? offer?.product?.name ?? sandboxId;
+}
+
+function getGameImageUrl(offer: Document | null | undefined) {
+  const keyImages = Array.isArray(offer?.keyImages) ? offer.keyImages : [];
+
+  if (keyImages.length === 0) {
+    return null;
+  }
+
+  return getImage(keyImages, GAME_IMAGE_TYPES)?.url ?? null;
+}
+
+function normalizePlayerGames(rows: Document[]) {
+  const bySandbox = new Map<string, NormalizedPlayerGame>();
+
+  for (const row of rows) {
+    const sandboxId = String(row.sandboxId ?? "");
+
+    if (!sandboxId) {
+      continue;
+    }
+
+    const existing =
+      bySandbox.get(sandboxId) ??
+      ({
+        sandboxId,
+        totalUnlocked: 0,
+        totalXP: 0,
+        playerAwards: [],
+        playerAchievements: [],
+      } satisfies NormalizedPlayerGame);
+
+    existing.totalUnlocked = Math.max(
+      existing.totalUnlocked,
+      Number(row.totalUnlocked ?? 0),
+    );
+    existing.totalXP = Math.max(existing.totalXP, Number(row.totalXP ?? 0));
+
+    const awardMap = new Map(
+      existing.playerAwards.map((award) => [stableAwardKey(award), award]),
+    );
+    for (const award of row.playerAwards ?? []) {
+      awardMap.set(stableAwardKey(award), award);
+    }
+    existing.playerAwards = Array.from(awardMap.values());
+
+    const achievementMap = new Map(
+      existing.playerAchievements.map((achievement) => [
+        stableAchievementKey(achievement),
+        achievement,
+      ]),
+    );
+    for (const playerAchievement of row.playerAchievements ?? []) {
+      const key = stableAchievementKey(playerAchievement);
+      const previous = achievementMap.get(key);
+
+      if (!previous) {
+        achievementMap.set(key, playerAchievement);
+        continue;
+      }
+
+      const previousAchievement = previous.playerAchievement ?? {};
+      const nextAchievement = playerAchievement.playerAchievement ?? {};
+      achievementMap.set(key, {
+        playerAchievement: {
+          ...previousAchievement,
+          ...nextAchievement,
+          unlocked:
+            Boolean(previousAchievement.unlocked) ||
+            Boolean(nextAchievement.unlocked),
+          unlockDate: latestDate(
+            previousAchievement.unlockDate,
+            nextAchievement.unlockDate,
+          ),
+          XP: Math.max(
+            Number(previousAchievement.XP ?? 0),
+            Number(nextAchievement.XP ?? 0),
+          ),
+        },
+      });
+    }
+    existing.playerAchievements = Array.from(achievementMap.values());
+
+    bySandbox.set(sandboxId, existing);
+  }
+
+  return Array.from(bySandbox.values());
+}
+
+function groupBySandbox(rows: Document[]) {
+  const bySandbox = new Map<string, Document[]>();
+
+  for (const row of rows) {
+    const sandboxId = String(row.sandboxId ?? row.namespace ?? "");
+
+    if (!sandboxId) {
+      continue;
+    }
+
+    const current = bySandbox.get(sandboxId) ?? [];
+    current.push(row);
+    bySandbox.set(sandboxId, current);
+  }
+
+  return bySandbox;
+}
+
+function chooseBaseOffer(offers: Document[]) {
+  return [...offers].sort((a, b) => {
+    const displayableA = a.isDisplayable ? 1 : 0;
+    const displayableB = b.isDisplayable ? 1 : 0;
+
+    if (displayableA !== displayableB) {
+      return displayableB - displayableA;
+    }
+
+    const titleCompare = String(a.title ?? "").localeCompare(
+      String(b.title ?? ""),
+    );
+
+    if (titleCompare !== 0) {
+      return titleCompare;
+    }
+
+    return toTime(b.lastModifiedDate) - toTime(a.lastModifiedDate);
+  })[0];
+}
+
+async function readCached<T>(
+  cacheKey: string,
+  ttlSeconds: number,
+  loader: () => Promise<T>,
+) {
+  const cached = await client.get(cacheKey);
+
+  if (cached) {
+    return JSON.parse(cached) as T;
+  }
+
+  const result = await loader();
+  await client.set(cacheKey, JSON.stringify(result), "EX", ttlSeconds);
+  return result;
+}
+
+function memoize<T>(
+  requestCache: ProfileRequestCache | undefined,
+  key: string,
+  loader: () => Promise<T>,
+) {
+  if (!requestCache) {
+    return loader();
+  }
+
+  const cached = requestCache.get(key) as Promise<T> | undefined;
+
+  if (cached) {
+    return cached;
+  }
+
+  const promise = loader();
+  requestCache.set(key, promise as Promise<unknown>);
+  return promise;
+}
+
+function findAchievementDetails(
+  achievementSetsBySandbox: Map<string, Document[]>,
+  sandboxId: string,
+  achievementSetId: string | undefined,
+  achievementName: string | undefined,
+) {
+  if (!achievementName) {
+    return null;
+  }
+
+  const sets = achievementSetsBySandbox.get(sandboxId) ?? [];
+
+  for (const set of sets) {
+    if (
+      achievementSetId &&
+      set.achievementSetId &&
+      set.achievementSetId !== achievementSetId
+    ) {
+      continue;
+    }
+
+    const achievement = (set.achievements ?? []).find(
+      (item: Document) => item.name === achievementName,
+    );
+
+    if (achievement) {
+      return achievement;
+    }
+  }
+
+  return null;
+}
+
+function buildAchievement(
+  row: PlayerAchievementRow,
+  achievementDetails: Document,
+  gameTitle: string,
+  sandboxId: string,
+): ProfileAchievement {
+  const playerAchievement = row.playerAchievement ?? {};
+  const name = String(
+    achievementDetails.name ?? playerAchievement.achievementName ?? "",
+  );
+
+  return {
+    name,
+    displayName: String(getAchievementDisplayName(achievementDetails)),
+    description: achievementDetails.description ?? null,
+    iconUrl: getAchievementIconUrl(achievementDetails),
+    rarityPercent: normalizeRarityPercent(achievementDetails.completedPercent),
+    xp: getAchievementXP(achievementDetails),
+    sandboxId,
+    gameTitle,
+    unlockedAt: playerAchievement.unlockDate ?? null,
+  };
+}
+
+function buildActivityItems(
+  game: NormalizedPlayerGame,
+  gameTitle: string,
+  achievements: ProfileAchievement[],
+) {
+  const achievementItems: ProfileActivityItem[] = achievements
+    .filter((achievement) => achievement.unlockedAt)
+    .map((achievement) => ({
+      type: "ACHIEVEMENT_UNLOCKED",
+      sandboxId: game.sandboxId,
+      gameTitle,
+      achievementName: achievement.displayName,
+      achievementIconUrl: achievement.iconUrl,
+      occurredAt: achievement.unlockedAt as string | Date,
+    }));
+
+  const awardItems: ProfileActivityItem[] = game.playerAwards
+    .filter((award) => award.unlockedDateTime)
+    .map((award) => ({
+      type: "PLATINUM_EARNED",
+      sandboxId: game.sandboxId,
+      gameTitle,
+      achievementName: null,
+      achievementIconUrl: null,
+      occurredAt: award.unlockedDateTime,
+    }));
+
+  return [...achievementItems, ...awardItems];
+}
+
+async function buildProfileAggregationData(accountId: string) {
+  const rows = await db.db
+    .collection("player-achievements")
+    .find({ epicAccountId: { $eq: accountId } })
+    .toArray();
+
+  const playerGames = normalizePlayerGames(rows);
+  const sandboxIds = playerGames.map((game) => game.sandboxId);
+
+  if (sandboxIds.length === 0) {
+    return {
+      games: [],
+      achievements: [],
+      activity: [],
+    } satisfies ProfileAggregationData;
+  }
+
+  const [offers, achievementSets] = await Promise.all([
+    Offer.find({
+      namespace: { $in: sandboxIds },
+      offerType: "BASE_GAME",
+      isCodeRedemptionOnly: false,
+    }).lean(),
+    AchievementSet.find({ sandboxId: { $in: sandboxIds } }).lean(),
+  ]);
+
+  const offersBySandbox = groupBySandbox(offers);
+  const achievementSetsBySandbox = groupBySandbox(achievementSets);
+  const games: ProfileGame[] = [];
+  const achievements: ProfileAchievement[] = [];
+  const activity: ProfileActivityItem[] = [];
+
+  for (const game of playerGames) {
+    const offer = chooseBaseOffer(offersBySandbox.get(game.sandboxId) ?? []);
+    const sets = achievementSetsBySandbox.get(game.sandboxId) ?? [];
+    const totalAchievements = sets.reduce(
+      (total, set) => total + (set.achievements?.length ?? 0),
+      0,
+    );
+    const totalXP = sets.reduce(
+      (total, set) =>
+        total +
+        (set.achievements ?? []).reduce(
+          (sum: number, achievement: Document) =>
+            sum + getAchievementXP(achievement),
+          0,
+        ),
+      0,
+    );
+    const unlockedAchievements = game.playerAchievements
+      .filter((row) => row.playerAchievement?.unlocked)
+      .map((row) => {
+        const playerAchievement = row.playerAchievement ?? {};
+        const achievementDetails = findAchievementDetails(
+          achievementSetsBySandbox,
+          game.sandboxId,
+          playerAchievement.achievementSetId,
+          playerAchievement.achievementName,
+        );
+
+        if (!achievementDetails) {
+          return null;
+        }
+
+        return buildAchievement(
+          row,
+          achievementDetails,
+          getGameTitle(offer, game.sandboxId),
+          game.sandboxId,
+        );
+      })
+      .filter((achievement): achievement is ProfileAchievement =>
+        Boolean(achievement),
+      );
+
+    unlockedAchievements.sort(sortAchievementsByRarity);
+    achievements.push(...unlockedAchievements);
+    activity.push(
+      ...buildActivityItems(
+        game,
+        getGameTitle(offer, game.sandboxId),
+        unlockedAchievements,
+      ),
+    );
+
+    games.push({
+      sandboxId: game.sandboxId,
+      title: getGameTitle(offer, game.sandboxId),
+      imageUrl: getGameImageUrl(offer),
+      completionPercent:
+        totalAchievements > 0
+          ? roundPercent((game.totalUnlocked / totalAchievements) * 100)
+          : 0,
+      unlocked: game.totalUnlocked,
+      total: totalAchievements,
+      earnedXP: game.totalXP,
+      totalXP,
+      hasPlatinum: game.playerAwards.length > 0,
+      platinumCount: game.playerAwards.length,
+      rarestAchievements: unlockedAchievements.slice(0, 3),
+    });
+  }
+
+  achievements.sort(sortAchievementsByRarity);
+  activity.sort((a, b) => toTime(b.occurredAt) - toTime(a.occurredAt));
+
+  return {
+    games,
+    achievements,
+    activity,
+  } satisfies ProfileAggregationData;
+}
+
+function sortAchievementsByRarity(
+  a: ProfileAchievement,
+  b: ProfileAchievement,
+) {
+  if (a.rarityPercent !== b.rarityPercent) {
+    return a.rarityPercent - b.rarityPercent;
+  }
+
+  if (a.xp !== b.xp) {
+    return b.xp - a.xp;
+  }
+
+  return toTime(b.unlockedAt) - toTime(a.unlockedAt);
+}
+
+function filterGames(games: ProfileGame[], filter: ProfileGameFilter) {
+  switch (filter) {
+    case "COMPLETED":
+      return games.filter((game) => game.completionPercent >= 100);
+    case "IN_PROGRESS":
+      return games.filter(
+        (game) =>
+          game.unlocked > 0 &&
+          game.completionPercent < 100 &&
+          !game.hasPlatinum,
+      );
+    case "NEAR_PLATINUM":
+      return games.filter(
+        (game) =>
+          game.unlocked > 0 &&
+          game.completionPercent >= 80 &&
+          game.completionPercent < 100 &&
+          !game.hasPlatinum,
+      );
+    case "PLATINUM":
+      return games.filter((game) => game.hasPlatinum);
+    default:
+      return games;
+  }
+}
+
+function sortGames(games: ProfileGame[], sort: ProfileGameSort) {
+  return [...games].sort((a, b) => {
+    if (sort === "ALPHABETICAL") {
+      return (
+        a.title.localeCompare(b.title) || a.sandboxId.localeCompare(b.sandboxId)
+      );
+    }
+
+    if (sort === "XP" && a.earnedXP !== b.earnedXP) {
+      return b.earnedXP - a.earnedXP;
+    }
+
+    if (sort === "ACHIEVEMENTS" && a.unlocked !== b.unlocked) {
+      return b.unlocked - a.unlocked;
+    }
+
+    if (a.completionPercent !== b.completionPercent) {
+      return b.completionPercent - a.completionPercent;
+    }
+
+    if (a.earnedXP !== b.earnedXP) {
+      return b.earnedXP - a.earnedXP;
+    }
+
+    if (a.unlocked !== b.unlocked) {
+      return b.unlocked - a.unlocked;
+    }
+
+    return (
+      a.title.localeCompare(b.title) || a.sandboxId.localeCompare(b.sandboxId)
+    );
+  });
+}
+
+function paginate<T>(items: T[], limit: number, page: number) {
+  const resolvedLimit = clampLimit(limit, DEFAULT_LIMIT);
+  const resolvedPage = clampPage(page);
+  const start = (resolvedPage - 1) * resolvedLimit;
+
+  return {
+    elements: items.slice(start, start + resolvedLimit),
+    total: items.length,
+    page: resolvedPage,
+    limit: resolvedLimit,
+  };
+}
+
+function getAggregationData(
+  accountId: string,
+  requestCache?: ProfileRequestCache,
+) {
+  return memoize(requestCache, `profile:${accountId}:aggregation`, () =>
+    buildProfileAggregationData(accountId),
+  );
+}
+
+export async function getProfileIdentity(
+  accountId: string,
+  requestCache?: ProfileRequestCache,
+) {
+  return memoize(requestCache, `profile:${accountId}:identity`, () =>
+    readCached<ProfileIdentity | null>(
+      `graphql:profile:${accountId}:identity:${PROFILE_CACHE_VERSION}`,
+      PROFILE_IDENTITY_TTL_SECONDS,
+      async () => {
+        const profile = await epicStoreClient.getUser(accountId);
+
+        if (!profile) {
+          return null;
+        }
+
+        const [dbProfile, reviewsCount] = await Promise.all([
+          db.db.collection("epic").findOne({
+            accountId: { $eq: accountId },
+          }),
+          Review.countDocuments({ userId: accountId }),
+        ]);
+
+        return {
+          accountId,
+          displayName: profile.displayName ?? null,
+          avatar: {
+            small:
+              dbProfile?.avatarUrl?.variants?.[0] ??
+              profile.avatar?.small ??
+              null,
+            medium:
+              dbProfile?.avatarUrl?.variants?.[0] ??
+              profile.avatar?.medium ??
+              null,
+            large:
+              dbProfile?.avatarUrl?.variants?.[0] ??
+              profile.avatar?.large ??
+              null,
+          },
+          linkedAccounts: dbProfile?.linkedAccounts ?? null,
+          creationDate: dbProfile?.creationDate ?? null,
+          reviewsCount,
+        };
+      },
+    ),
+  );
+}
+
+export async function getProfileGames(
+  accountId: string,
+  args: {
+    filter?: ProfileGameFilter;
+    sort?: ProfileGameSort;
+  } = {},
+  requestCache?: ProfileRequestCache,
+) {
+  const filter = args.filter ?? "ALL";
+  const sort = args.sort ?? "COMPLETION";
+
+  return memoize(
+    requestCache,
+    `profile:${accountId}:games:${filter}:${sort}`,
+    () =>
+      readCached<ProfileGame[]>(
+        `graphql:profile:${accountId}:games:${filter}:${sort}:${PROFILE_CACHE_VERSION}`,
+        PROFILE_GAMES_TTL_SECONDS,
+        async () => {
+          const data = await getAggregationData(accountId, requestCache);
+          return sortGames(filterGames(data.games, filter), sort);
+        },
+      ),
+  );
+}
+
+export async function getProfileHighlights(
+  accountId: string,
+  reviewsCount: number,
+  requestCache?: ProfileRequestCache,
+) {
+  return memoize(requestCache, `profile:${accountId}:highlights`, () =>
+    readCached<ProfileHighlights>(
+      `graphql:profile:${accountId}:highlights:${PROFILE_CACHE_VERSION}`,
+      PROFILE_HIGHLIGHTS_TTL_SECONDS,
+      async () => {
+        const games = await getProfileGames(
+          accountId,
+          { filter: "ALL", sort: "COMPLETION" },
+          requestCache,
+        );
+        const totalPlatinums = games.reduce(
+          (sum, game) =>
+            sum + (game.platinumCount ?? (game.hasPlatinum ? 1 : 0)),
+          0,
+        );
+        const totalXP =
+          games.reduce((sum, game) => sum + game.earnedXP, 0) +
+          totalPlatinums * PLATINUM_XP;
+
+        return {
+          level: Math.floor(totalXP / PLATINUM_XP),
+          totalXP,
+          totalGames: games.length,
+          totalAchievements: games.reduce(
+            (sum, game) => sum + game.unlocked,
+            0,
+          ),
+          totalPlatinums,
+          reviewsCount,
+        };
+      },
+    ),
+  );
+}
+
+export async function getProfileHeroGame(
+  accountId: string,
+  requestCache?: ProfileRequestCache,
+) {
+  const games = await getProfileGames(
+    accountId,
+    { filter: "ALL", sort: "COMPLETION" },
+    requestCache,
+  );
+
+  return (
+    [...games].sort((a, b) => {
+      const imageA = a.imageUrl ? 1 : 0;
+      const imageB = b.imageUrl ? 1 : 0;
+
+      if (imageA !== imageB) {
+        return imageB - imageA;
+      }
+
+      if (a.completionPercent !== b.completionPercent) {
+        return b.completionPercent - a.completionPercent;
+      }
+
+      if (a.earnedXP !== b.earnedXP) {
+        return b.earnedXP - a.earnedXP;
+      }
+
+      if (a.unlocked !== b.unlocked) {
+        return b.unlocked - a.unlocked;
+      }
+
+      return (
+        a.title.localeCompare(b.title) || a.sandboxId.localeCompare(b.sandboxId)
+      );
+    })[0] ?? null
+  );
+}
+
+export async function getFeaturedAchievements(
+  accountId: string,
+  limit: number | undefined,
+  requestCache?: ProfileRequestCache,
+) {
+  const resolvedLimit = clampLimit(limit, 8);
+
+  return memoize(
+    requestCache,
+    `profile:${accountId}:featured-achievements:${resolvedLimit}`,
+    () =>
+      readCached<ProfileAchievement[]>(
+        `graphql:profile:${accountId}:featured-achievements:${resolvedLimit}:${PROFILE_CACHE_VERSION}`,
+        PROFILE_ACHIEVEMENTS_TTL_SECONDS,
+        async () => {
+          const data = await getAggregationData(accountId, requestCache);
+          return data.achievements.slice(0, resolvedLimit);
+        },
+      ),
+  );
+}
+
+export async function getRecentActivity(
+  accountId: string,
+  limit: number | undefined,
+  page: number | undefined,
+  requestCache?: ProfileRequestCache,
+) {
+  const resolvedLimit = clampLimit(limit, DEFAULT_LIMIT);
+  const resolvedPage = clampPage(page);
+
+  return memoize(
+    requestCache,
+    `profile:${accountId}:activity:${resolvedLimit}:${resolvedPage}`,
+    () =>
+      readCached<ProfileActivityItem[]>(
+        `graphql:profile:${accountId}:activity:${resolvedLimit}:${resolvedPage}:${PROFILE_CACHE_VERSION}`,
+        PROFILE_ACTIVITY_TTL_SECONDS,
+        async () => {
+          const data = await getAggregationData(accountId, requestCache);
+          const start = (resolvedPage - 1) * resolvedLimit;
+          return data.activity.slice(start, start + resolvedLimit);
+        },
+      ),
+  );
+}
+
+export async function getFeaturedGames(
+  accountId: string,
+  args: {
+    filter?: ProfileGameFilter;
+    limit?: number;
+    sort?: ProfileGameSort;
+  },
+  requestCache?: ProfileRequestCache,
+) {
+  const games = await getProfileGames(
+    accountId,
+    {
+      filter: args.filter ?? "ALL",
+      sort: args.sort ?? "COMPLETION",
+    },
+    requestCache,
+  );
+
+  return games.slice(0, clampLimit(args.limit, 6));
+}
+
+export async function getProfileGameConnection(
+  accountId: string,
+  args: {
+    filter?: ProfileGameFilter;
+    limit?: number;
+    page?: number;
+    sort?: ProfileGameSort;
+  },
+  requestCache?: ProfileRequestCache,
+): Promise<ProfileGameConnection> {
+  const games = await getProfileGames(
+    accountId,
+    {
+      filter: args.filter ?? "ALL",
+      sort: args.sort ?? "COMPLETION",
+    },
+    requestCache,
+  );
+
+  return paginate(games, args.limit ?? DEFAULT_LIMIT, args.page ?? 1);
+}
+
+export async function getProfileAchievementConnection(
+  accountId: string,
+  limit: number | undefined,
+  page: number | undefined,
+  requestCache?: ProfileRequestCache,
+): Promise<ProfileAchievementConnection> {
+  const data = await getAggregationData(accountId, requestCache);
+  return paginate(
+    data.achievements,
+    limit ?? DEFAULT_ACHIEVEMENT_LIMIT,
+    page ?? 1,
+  );
+}

--- a/src/graphql/services/profile.ts
+++ b/src/graphql/services/profile.ts
@@ -768,38 +768,41 @@ export async function getProfileHighlights(
   reviewsCount: number,
   requestCache?: ProfileRequestCache,
 ) {
-  return memoize(requestCache, `profile:${accountId}:highlights`, () =>
-    readCached<ProfileHighlights>(
-      `graphql:profile:${accountId}:highlights:${PROFILE_CACHE_VERSION}`,
-      PROFILE_HIGHLIGHTS_TTL_SECONDS,
-      async () => {
-        const games = await getProfileGames(
-          accountId,
-          { filter: "ALL", sort: "COMPLETION" },
-          requestCache,
-        );
-        const totalPlatinums = games.reduce(
-          (sum, game) =>
-            sum + (game.platinumCount ?? (game.hasPlatinum ? 1 : 0)),
-          0,
-        );
-        const totalXP =
-          games.reduce((sum, game) => sum + game.earnedXP, 0) +
-          totalPlatinums * PLATINUM_XP;
-
-        return {
-          level: Math.floor(totalXP / PLATINUM_XP),
-          totalXP,
-          totalGames: games.length,
-          totalAchievements: games.reduce(
-            (sum, game) => sum + game.unlocked,
+  return memoize(
+    requestCache,
+    `profile:${accountId}:highlights:reviews:${reviewsCount}`,
+    () =>
+      readCached<ProfileHighlights>(
+        `graphql:profile:${accountId}:highlights:reviews:${reviewsCount}:${PROFILE_CACHE_VERSION}`,
+        PROFILE_HIGHLIGHTS_TTL_SECONDS,
+        async () => {
+          const games = await getProfileGames(
+            accountId,
+            { filter: "ALL", sort: "COMPLETION" },
+            requestCache,
+          );
+          const totalPlatinums = games.reduce(
+            (sum, game) =>
+              sum + (game.platinumCount ?? (game.hasPlatinum ? 1 : 0)),
             0,
-          ),
-          totalPlatinums,
-          reviewsCount,
-        };
-      },
-    ),
+          );
+          const totalXP =
+            games.reduce((sum, game) => sum + game.earnedXP, 0) +
+            totalPlatinums * PLATINUM_XP;
+
+          return {
+            level: Math.floor(totalXP / PLATINUM_XP),
+            totalXP,
+            totalGames: games.length,
+            totalAchievements: games.reduce(
+              (sum, game) => sum + game.unlocked,
+              0,
+            ),
+            totalPlatinums,
+            reviewsCount,
+          };
+        },
+      ),
   );
 }
 

--- a/src/graphql/typedefs.ts
+++ b/src/graphql/typedefs.ts
@@ -21,6 +21,9 @@ export const typeDefs = `#graphql
         sandboxHub(id: ID!, country: String, offerLimit: Int, updateLimit: Int): SandboxHub
         sandboxes(limit: Int, page: Int): SandboxConnection
 
+        # Profiles
+        profile(id: ID!): Profile
+
         # Misc
         build(id: ID!): Build
         builds(limit: Int, page: Int, sortBy: String, sortDir: String): [Build]
@@ -59,6 +62,112 @@ export const typeDefs = `#graphql
 
     type SandboxConnection {
         elements: [Sandbox]
+        total: Int
+        page: Int
+        limit: Int
+    }
+
+    enum ProfileGameSort {
+        COMPLETION
+        ALPHABETICAL
+        XP
+        ACHIEVEMENTS
+    }
+
+    enum ProfileGameFilter {
+        ALL
+        COMPLETED
+        NEAR_PLATINUM
+        IN_PROGRESS
+        PLATINUM
+    }
+
+    enum ProfileActivityType {
+        ACHIEVEMENT_UNLOCKED
+        PLATINUM_EARNED
+    }
+
+    type Profile {
+        accountId: ID
+        displayName: String
+        avatar: ProfileAvatar
+        linkedAccounts: JSON
+        creationDate: Date
+        reviewsCount: Int
+        highlights: ProfileHighlights
+        heroGame: ProfileHeroGame
+        featuredAchievements(limit: Int = 8): [ProfileAchievement]
+        featuredGames(limit: Int = 6, filter: ProfileGameFilter = ALL, sort: ProfileGameSort = COMPLETION): [ProfileGame]
+        recentActivity(limit: Int = 12, page: Int = 1): [ProfileActivityItem]
+        games(limit: Int = 12, page: Int = 1, filter: ProfileGameFilter = ALL, sort: ProfileGameSort = COMPLETION): ProfileGameConnection
+        achievements(limit: Int = 25, page: Int = 1): ProfileAchievementConnection
+    }
+
+    type ProfileAvatar {
+        small: String
+        medium: String
+        large: String
+    }
+
+    type ProfileHighlights {
+        level: Int
+        totalXP: Int
+        totalGames: Int
+        totalAchievements: Int
+        totalPlatinums: Int
+        reviewsCount: Int
+    }
+
+    type ProfileHeroGame {
+        sandboxId: String
+        title: String
+        imageUrl: String
+        completionPercent: Float
+    }
+
+    type ProfileGame {
+        sandboxId: String
+        title: String
+        imageUrl: String
+        completionPercent: Float
+        unlocked: Int
+        total: Int
+        earnedXP: Int
+        totalXP: Int
+        hasPlatinum: Boolean
+        rarestAchievements: [ProfileAchievement]
+    }
+
+    type ProfileAchievement {
+        name: String
+        displayName: String
+        description: String
+        iconUrl: String
+        rarityPercent: Float
+        xp: Int
+        sandboxId: String
+        gameTitle: String
+        unlockedAt: Date
+    }
+
+    type ProfileActivityItem {
+        type: ProfileActivityType
+        sandboxId: String
+        gameTitle: String
+        achievementName: String
+        achievementIconUrl: String
+        occurredAt: Date
+    }
+
+    type ProfileGameConnection {
+        elements: [ProfileGame]
+        total: Int
+        page: Int
+        limit: Int
+    }
+
+    type ProfileAchievementConnection {
+        elements: [ProfileAchievement]
         total: Int
         page: Int
         limit: Int

--- a/tests/profile-resolver.test.ts
+++ b/tests/profile-resolver.test.ts
@@ -119,7 +119,7 @@ const playerAchievementRows = [
   {
     epicAccountId: "player-1",
     sandboxId: "sandbox-a",
-    totalXP: 600,
+    totalXP: 225,
     totalUnlocked: 3,
     playerAwards: [
       {
@@ -164,7 +164,7 @@ const playerAchievementRows = [
   {
     epicAccountId: "player-1",
     sandboxId: "sandbox-b",
-    totalXP: 100,
+    totalXP: 25,
     totalUnlocked: 1,
     playerAwards: [],
     playerAchievements: [
@@ -350,13 +350,32 @@ describe("profile GraphQL resolver", () => {
     );
 
     expect(highlights).toEqual({
-      level: 3,
-      totalXP: 950,
+      level: 2,
+      totalXP: 500,
       totalGames: 2,
       totalAchievements: 4,
       totalPlatinums: 1,
       reviewsCount: 2,
     });
+
+    const refreshedProfile = {
+      ...(profile as Record<string, unknown>),
+      reviewsCount: 3,
+    };
+    const refreshedHighlights = await profileResolver("highlights")(
+      refreshedProfile,
+      {},
+      context,
+      {},
+    );
+
+    expect(refreshedHighlights).toMatchObject({ reviewsCount: 3 });
+    expect(mocks.redisGet).toHaveBeenCalledWith(
+      expect.stringContaining("graphql:profile:player-1:highlights:reviews:2:"),
+    );
+    expect(mocks.redisGet).toHaveBeenCalledWith(
+      expect.stringContaining("graphql:profile:player-1:highlights:reviews:3:"),
+    );
   });
 
   it("returns featured achievements sorted by rarity, XP, and unlock date", async () => {
@@ -412,7 +431,7 @@ describe("profile GraphQL resolver", () => {
       completionPercent: 100,
       unlocked: 3,
       total: 3,
-      earnedXP: 600,
+      earnedXP: 225,
       totalXP: 225,
       hasPlatinum: true,
     });

--- a/tests/profile-resolver.test.ts
+++ b/tests/profile-resolver.test.ts
@@ -1,0 +1,484 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import profileResolvers from "../src/graphql/resolvers/profile.js";
+
+type Resolver = (
+  parent: unknown,
+  args: Record<string, unknown>,
+  context: Record<string, unknown>,
+  info: unknown,
+) => Promise<unknown>;
+
+type ProfileAchievementResult = {
+  displayName: string;
+  iconUrl: string;
+  rarityPercent: number;
+  xp: number;
+  sandboxId: string;
+  gameTitle: string;
+};
+
+type ProfileActivityResult = {
+  type: string;
+  occurredAt: string;
+  gameTitle: string;
+  achievementName: string;
+  achievementIconUrl: string;
+};
+
+type ProfileGameResult = {
+  sandboxId: string;
+  title: string;
+  imageUrl: string;
+  completionPercent: number;
+  unlocked: number;
+  total: number;
+  earnedXP: number;
+  totalXP: number;
+  hasPlatinum: boolean;
+  rarestAchievements: ProfileAchievementResult[];
+};
+
+type QueryLike = {
+  lean: ReturnType<typeof vi.fn>;
+};
+
+const mocks = vi.hoisted(() => ({
+  achievementSetFind: vi.fn(),
+  collection: vi.fn(),
+  epicFindOne: vi.fn(),
+  epicGetUser: vi.fn(),
+  offerFind: vi.fn(),
+  playerAchievementsFind: vi.fn(),
+  playerAchievementsToArray: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+  reviewCountDocuments: vi.fn(),
+}));
+
+vi.mock("../src/clients/epic.js", () => ({
+  epicStoreClient: {
+    getUser: mocks.epicGetUser,
+  },
+}));
+
+vi.mock("../src/clients/redis.js", () => ({
+  default: {
+    get: mocks.redisGet,
+    set: mocks.redisSet,
+  },
+}));
+
+vi.mock("../src/db/index.js", () => ({
+  db: {
+    db: {
+      collection: mocks.collection,
+    },
+  },
+}));
+
+vi.mock("../src/models/index.js", () => ({
+  AchievementSet: {
+    find: mocks.achievementSetFind,
+  },
+  Offer: {
+    find: mocks.offerFind,
+  },
+  Review: {
+    countDocuments: mocks.reviewCountDocuments,
+  },
+}));
+
+function lean<T>(value: T): QueryLike {
+  return {
+    lean: vi.fn().mockResolvedValue(value),
+  };
+}
+
+const epicProfile = {
+  epicAccountId: "player-1",
+  displayName: "Player One",
+  avatar: {
+    small: "https://example.test/epic-small.png",
+    medium: "https://example.test/epic-medium.png",
+    large: "https://example.test/epic-large.png",
+  },
+};
+
+const dbProfile = {
+  accountId: "player-1",
+  avatarUrl: {
+    variants: ["https://example.test/db-avatar.png"],
+  },
+  linkedAccounts: {
+    steam: "steam-player",
+  },
+  creationDate: "2024-01-01T00:00:00.000Z",
+};
+
+const playerAchievementRows = [
+  {
+    epicAccountId: "player-1",
+    sandboxId: "sandbox-a",
+    totalXP: 600,
+    totalUnlocked: 3,
+    playerAwards: [
+      {
+        awardType: "PLATINUM",
+        unlockedDateTime: "2024-05-04T00:00:00.000Z",
+        achievementSetId: "set-a",
+      },
+    ],
+    playerAchievements: [
+      {
+        playerAchievement: {
+          achievementName: "rare-a",
+          achievementSetId: "set-a",
+          sandboxId: "sandbox-a",
+          unlocked: true,
+          unlockDate: "2024-05-03T00:00:00.000Z",
+          XP: 100,
+        },
+      },
+      {
+        playerAchievement: {
+          achievementName: "medium-a",
+          achievementSetId: "set-a",
+          sandboxId: "sandbox-a",
+          unlocked: true,
+          unlockDate: "2024-05-02T00:00:00.000Z",
+          XP: 75,
+        },
+      },
+      {
+        playerAchievement: {
+          achievementName: "common-a",
+          achievementSetId: "set-a",
+          sandboxId: "sandbox-a",
+          unlocked: true,
+          unlockDate: "2024-05-01T00:00:00.000Z",
+          XP: 50,
+        },
+      },
+    ],
+  },
+  {
+    epicAccountId: "player-1",
+    sandboxId: "sandbox-b",
+    totalXP: 100,
+    totalUnlocked: 1,
+    playerAwards: [],
+    playerAchievements: [
+      {
+        playerAchievement: {
+          achievementName: "rare-b",
+          achievementSetId: "set-b",
+          sandboxId: "sandbox-b",
+          unlocked: true,
+          unlockDate: "2024-04-01T00:00:00.000Z",
+          XP: 25,
+        },
+      },
+    ],
+  },
+];
+
+const offers = [
+  {
+    namespace: "sandbox-a",
+    title: "Alpha Game",
+    isDisplayable: true,
+    lastModifiedDate: "2024-01-10T00:00:00.000Z",
+    keyImages: [
+      {
+        type: "OfferImageWide",
+        url: "https://example.test/alpha-wide.jpg",
+        md5: "alpha",
+      },
+    ],
+  },
+  {
+    namespace: "sandbox-b",
+    title: "Beta Game",
+    isDisplayable: true,
+    lastModifiedDate: "2024-01-11T00:00:00.000Z",
+    keyImages: [
+      {
+        type: "OfferImageWide",
+        url: "https://example.test/beta-wide.jpg",
+        md5: "beta",
+      },
+    ],
+  },
+];
+
+const achievementSets = [
+  {
+    sandboxId: "sandbox-a",
+    achievementSetId: "set-a",
+    isBase: true,
+    achievements: [
+      {
+        name: "rare-a",
+        displayName: "Rare Alpha",
+        description: "Rare Alpha description",
+        unlockedIcon: "https://example.test/rare-alpha.png",
+        completedPercent: 1.5,
+        xp: 100,
+      },
+      {
+        name: "medium-a",
+        displayName: "Medium Alpha",
+        description: "Medium Alpha description",
+        unlockedIcon: "https://example.test/medium-alpha.png",
+        completedPercent: 35,
+        xp: 75,
+      },
+      {
+        name: "common-a",
+        displayName: "Common Alpha",
+        description: "Common Alpha description",
+        unlockedIcon: "https://example.test/common-alpha.png",
+        completedPercent: 60,
+        xp: 50,
+      },
+    ],
+  },
+  {
+    sandboxId: "sandbox-b",
+    achievementSetId: "set-b",
+    isBase: true,
+    achievements: [
+      {
+        name: "rare-b",
+        displayName: "Rare Beta",
+        description: "Rare Beta description",
+        unlockedIcon: "https://example.test/rare-beta.png",
+        completedPercent: 2,
+        xp: 25,
+      },
+      {
+        name: "locked-b",
+        displayName: "Locked Beta",
+        description: "Locked Beta description",
+        unlockedIcon: "https://example.test/locked-beta.png",
+        completedPercent: 20,
+        xp: 25,
+      },
+    ],
+  },
+];
+
+function queryResolver(name: string) {
+  return (profileResolvers.Query as Record<string, Resolver>)[name];
+}
+
+function profileResolver(name: string) {
+  return (profileResolvers.Profile as Record<string, Resolver>)[name];
+}
+
+async function getProfile(context: Record<string, unknown> = {}) {
+  return queryResolver("profile")(null, { id: "player-1" }, context, {});
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.redisGet.mockResolvedValue(null);
+  mocks.redisSet.mockResolvedValue("OK");
+  mocks.epicGetUser.mockResolvedValue(epicProfile);
+  mocks.epicFindOne.mockResolvedValue(dbProfile);
+  mocks.reviewCountDocuments.mockResolvedValue(2);
+  mocks.playerAchievementsToArray.mockResolvedValue(playerAchievementRows);
+  mocks.playerAchievementsFind.mockReturnValue({
+    toArray: mocks.playerAchievementsToArray,
+  });
+  mocks.offerFind.mockReturnValue(lean(offers));
+  mocks.achievementSetFind.mockReturnValue(lean(achievementSets));
+  mocks.collection.mockImplementation((name: string) => {
+    if (name === "epic") {
+      return {
+        findOne: mocks.epicFindOne,
+      };
+    }
+
+    if (name === "player-achievements") {
+      return {
+        find: mocks.playerAchievementsFind,
+      };
+    }
+
+    throw new Error(`Unexpected collection ${name}`);
+  });
+});
+
+describe("profile GraphQL resolver", () => {
+  it("returns null for a missing Epic profile", async () => {
+    mocks.epicGetUser.mockResolvedValue(null);
+
+    await expect(getProfile()).resolves.toBeNull();
+    expect(mocks.epicFindOne).not.toHaveBeenCalled();
+    expect(mocks.reviewCountDocuments).not.toHaveBeenCalled();
+  });
+
+  it("returns base identity with database avatar and linked accounts", async () => {
+    const profile = await getProfile();
+
+    expect(profile).toMatchObject({
+      accountId: "player-1",
+      displayName: "Player One",
+      avatar: {
+        small: "https://example.test/db-avatar.png",
+        medium: "https://example.test/db-avatar.png",
+        large: "https://example.test/db-avatar.png",
+      },
+      linkedAccounts: {
+        steam: "steam-player",
+      },
+      creationDate: "2024-01-01T00:00:00.000Z",
+      reviewsCount: 2,
+    });
+  });
+
+  it("aggregates highlights with platinum XP and level calculation", async () => {
+    const context = {};
+    const profile = await getProfile(context);
+    const highlights = await profileResolver("highlights")(
+      profile,
+      {},
+      context,
+      {},
+    );
+
+    expect(highlights).toEqual({
+      level: 3,
+      totalXP: 950,
+      totalGames: 2,
+      totalAchievements: 4,
+      totalPlatinums: 1,
+      reviewsCount: 2,
+    });
+  });
+
+  it("returns featured achievements sorted by rarity, XP, and unlock date", async () => {
+    const context = {};
+    const profile = await getProfile(context);
+    const achievements = (await profileResolver("featuredAchievements")(
+      profile,
+      { limit: 3 },
+      context,
+      {},
+    )) as ProfileAchievementResult[];
+
+    expect(achievements.map((achievement) => achievement.displayName)).toEqual([
+      "Rare Alpha",
+      "Rare Beta",
+      "Medium Alpha",
+    ]);
+    expect(achievements[0]).toMatchObject({
+      sandboxId: "sandbox-a",
+      gameTitle: "Alpha Game",
+      iconUrl: "https://example.test/rare-alpha.png",
+      rarityPercent: 1.5,
+      xp: 100,
+    });
+  });
+
+  it("filters and sorts featured games and paginated game connections", async () => {
+    const context = {};
+    const profile = await getProfile(context);
+    const featuredGames = (await profileResolver("featuredGames")(
+      profile,
+      { filter: "ALL", limit: 1, sort: "XP" },
+      context,
+      {},
+    )) as ProfileGameResult[];
+    const inProgressGames = await profileResolver("games")(
+      profile,
+      {
+        filter: "IN_PROGRESS",
+        limit: 12,
+        page: 1,
+        sort: "ALPHABETICAL",
+      },
+      context,
+      {},
+    );
+
+    expect(featuredGames).toHaveLength(1);
+    expect(featuredGames[0]).toMatchObject({
+      sandboxId: "sandbox-a",
+      title: "Alpha Game",
+      imageUrl: "https://example.test/alpha-wide.jpg",
+      completionPercent: 100,
+      unlocked: 3,
+      total: 3,
+      earnedXP: 600,
+      totalXP: 225,
+      hasPlatinum: true,
+    });
+    expect(featuredGames[0].rarestAchievements).toHaveLength(3);
+    expect(inProgressGames).toMatchObject({
+      total: 1,
+      page: 1,
+      limit: 12,
+      elements: [
+        {
+          sandboxId: "sandbox-b",
+          title: "Beta Game",
+          completionPercent: 50,
+        },
+      ],
+    });
+  });
+
+  it("returns recent activity sorted newest first with supported activity types", async () => {
+    const context = {};
+    const profile = await getProfile(context);
+    const activity = (await profileResolver("recentActivity")(
+      profile,
+      { limit: 3, page: 1 },
+      context,
+      {},
+    )) as ProfileActivityResult[];
+
+    expect(activity.map((item) => item.type)).toEqual([
+      "PLATINUM_EARNED",
+      "ACHIEVEMENT_UNLOCKED",
+      "ACHIEVEMENT_UNLOCKED",
+    ]);
+    expect(activity.map((item) => item.occurredAt)).toEqual([
+      "2024-05-04T00:00:00.000Z",
+      "2024-05-03T00:00:00.000Z",
+      "2024-05-02T00:00:00.000Z",
+    ]);
+    expect(activity[1]).toMatchObject({
+      gameTitle: "Alpha Game",
+      achievementName: "Rare Alpha",
+      achievementIconUrl: "https://example.test/rare-alpha.png",
+    });
+  });
+
+  it("reuses profile aggregation work across selected fields in one request", async () => {
+    const context = {};
+    const profile = await getProfile(context);
+
+    await profileResolver("highlights")(profile, {}, context, {});
+    await profileResolver("featuredGames")(
+      profile,
+      { filter: "ALL", limit: 2, sort: "COMPLETION" },
+      context,
+      {},
+    );
+    await profileResolver("recentActivity")(
+      profile,
+      { limit: 5, page: 1 },
+      context,
+      {},
+    );
+
+    expect(mocks.playerAchievementsFind).toHaveBeenCalledTimes(1);
+    expect(mocks.playerAchievementsToArray).toHaveBeenCalledTimes(1);
+    expect(mocks.offerFind).toHaveBeenCalledTimes(1);
+    expect(mocks.achievementSetFind).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add new GraphQL profile showcase data and wire it through the schema, resolver, and service layer
- Update the profile GraphQL docs to describe the new response shape
- Add changelog coverage for the public-facing change
- Extend resolver tests for the new profile behavior

## Testing
- Added and updated resolver tests for profile queries
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public GraphQL queries: profile(id) for public profile data and sandboxHub for aggregated sandbox product data.

* **Documentation**
  * Added a GraphQL profiles guide with examples, pagination, filters/sorts, and error semantics.
  * Updated changelog with Unreleased entries and added an in-repo docs scaffold plus an API OpenAPI contract.

* **Tests**
  * Added resolver tests validating profile query behavior, aggregation, pagination, and caching.

* **Chores**
  * Tightened release policy and changelog enforcement checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egdata-app/egdata-api/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->