### PR TITLE
Fix GraphQL profile achievement metadata mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable public API, documentation, release, and sustainability changes shoul
 ## Unreleased
 
 - Added a public GraphQL `profile(id)` query for profile identity, highlights, featured games, achievements, and recent activity.
+- Fixed GraphQL profile achievements to read Epic unlocked achievement names, descriptions, and icon links from stored achievement metadata.
 - Added a GraphQL `sandboxHub` query that aggregates sandbox product data for user-facing product pages.
 - Added CodeRabbit configuration to enforce changelog updates and docs/OpenAPI coverage for public endpoint structure changes.
 - Tightened the release policy so user-facing and maintainer-facing changes require `CHANGELOG.md` entries.

--- a/src/graphql/services/profile.ts
+++ b/src/graphql/services/profile.ts
@@ -117,7 +117,7 @@ type ProfileAggregationData = {
   activity: ProfileActivityItem[];
 };
 
-const PROFILE_CACHE_VERSION = "v1";
+const PROFILE_CACHE_VERSION = "v2";
 const PROFILE_IDENTITY_TTL_SECONDS = 3600;
 const PROFILE_HIGHLIGHTS_TTL_SECONDS = 300;
 const PROFILE_GAMES_TTL_SECONDS = 60;
@@ -207,22 +207,46 @@ function getAchievementXP(achievement: Document) {
   return Number.isFinite(xp) ? xp : 0;
 }
 
+function firstNonEmptyString(...values: unknown[]) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
 function getAchievementIconUrl(achievement: Document) {
-  return (
-    achievement.unlockedIcon ??
-    achievement.lockedIcon ??
-    achievement.iconUrl ??
-    achievement.icon ??
-    null
+  return firstNonEmptyString(
+    achievement.unlockedIconLink,
+    achievement.unlockedIcon,
+    achievement.iconUrl,
+    achievement.icon,
+    achievement.iconLink,
+    achievement.lockedIconLink,
+    achievement.lockedIcon,
   );
 }
 
 function getAchievementDisplayName(achievement: Document) {
   return (
-    achievement.displayName ??
-    achievement.title ??
-    achievement.name ??
-    "Unknown achievement"
+    firstNonEmptyString(
+      achievement.unlockedDisplayName,
+      achievement.displayName,
+      achievement.title,
+      achievement.lockedDisplayName,
+      achievement.name,
+    ) ?? "Unknown achievement"
+  );
+}
+
+function getAchievementDescription(achievement: Document) {
+  return firstNonEmptyString(
+    achievement.unlockedDescription,
+    achievement.description,
+    achievement.lockedDescription,
+    achievement.flavorText,
   );
 }
 
@@ -439,7 +463,7 @@ function buildAchievement(
   return {
     name,
     displayName: String(getAchievementDisplayName(achievementDetails)),
-    description: achievementDetails.description ?? null,
+    description: getAchievementDescription(achievementDetails),
     iconUrl: getAchievementIconUrl(achievementDetails),
     rarityPercent: normalizeRarityPercent(achievementDetails.completedPercent),
     xp: getAchievementXP(achievementDetails),

--- a/tests/profile-resolver.test.ts
+++ b/tests/profile-resolver.test.ts
@@ -9,6 +9,7 @@ type Resolver = (
 ) => Promise<unknown>;
 
 type ProfileAchievementResult = {
+  description: string | null;
   displayName: string;
   iconUrl: string;
   rarityPercent: number;
@@ -219,9 +220,9 @@ const achievementSets = [
     achievements: [
       {
         name: "rare-a",
-        displayName: "Rare Alpha",
-        description: "Rare Alpha description",
-        unlockedIcon: "https://example.test/rare-alpha.png",
+        unlockedDisplayName: "Rare Alpha",
+        unlockedDescription: "Rare Alpha description",
+        unlockedIconLink: "https://example.test/rare-alpha.png",
         completedPercent: 1.5,
         xp: 100,
       },
@@ -396,6 +397,7 @@ describe("profile GraphQL resolver", () => {
     expect(achievements[0]).toMatchObject({
       sandboxId: "sandbox-a",
       gameTitle: "Alpha Game",
+      description: "Rare Alpha description",
       iconUrl: "https://example.test/rare-alpha.png",
       rarityPercent: 1.5,
       xp: 100,


### PR DESCRIPTION
## Summary
- Read GraphQL profile achievements from the stored Epic metadata fields for unlocked display names, descriptions, and icon links
- Bump the profile GraphQL cache version so old cached null metadata is not reused
- Update the profile resolver test fixture to cover the real achievement field shape and add a changelog entry

## Testing
- Added and updated unit coverage for achievement metadata mapping
- `vitest` profile resolver tests passed
- Build and release policy checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile achievements now correctly display unlocked achievement names, descriptions, and icon links from stored metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egdata-app/egdata-api/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->