### PR TITLE
Hydrate changelog search values and harden changelist detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable public API, documentation, release, and sustainability changes shoul
 
 ## Unreleased
 
+- Fixed changelog search responses to hydrate old/new change values and made changelist detail context enrichment more resilient.
 - Added a public GraphQL `profile(id)` query for profile identity, highlights, featured games, achievements, and recent activity.
 - Added a GraphQL `sandboxHub` query that aggregates sandbox product data for user-facing product pages.
 - Added CodeRabbit configuration to enforce changelog updates and docs/OpenAPI coverage for public endpoint structure changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable public API, documentation, release, and sustainability changes shoul
 
 ## Unreleased
 
+- Normalized free-game promotion responses so `countriesBlacklist`, `giveaway.offerId`, and `giveaway.platform` keep a stable shape.
 - Fixed changelog search responses to hydrate old/new change values and made changelist detail context enrichment more resilient.
 - Added a public GraphQL `profile(id)` query for profile identity, highlights, featured games, achievements, and recent activity.
 - Added a GraphQL `sandboxHub` query that aggregates sandbox product data for user-facing product pages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable public API, documentation, release, and sustainability changes shoul
 ## Unreleased
 
 - Normalized free-game promotion responses so `countriesBlacklist`, `giveaway.offerId`, and `giveaway.platform` keep a stable shape.
+- Documented changelog context/search enrichment fields and made changelist list context enrichment use the shared safe resolver.
 - Fixed changelog search responses to hydrate old/new change values and made changelist detail context enrichment more resilient.
 - Added a public GraphQL `profile(id)` query for profile identity, highlights, featured games, achievements, and recent activity.
 - Added a GraphQL `sandboxHub` query that aggregates sandbox product data for user-facing product pages.

--- a/apps/docs/content/docs/changelog-deprecations.mdx
+++ b/apps/docs/content/docs/changelog-deprecations.mdx
@@ -9,6 +9,10 @@ The API evolves with Epic Games Store data and with the internal schemas used by
 
 Changelog endpoints expose observed changes in catalog data, including offer and item updates. Use these routes when you need to sync downstream systems without polling every resource.
 
+`GET /search/changelog` is the search-optimized route. Each hit includes `metadata.changes[]` entries where `oldValue` and `newValue` are hydrated from canonical changelog records when available, or parsed from `oldValueRaw` and `newValueRaw` when the search index only has raw values. Raw fields may still be present for compatibility.
+
+`GET /changelist` and `GET /changelist/{id}` return recent or specific changelog records with best-effort `metadata.context` enrichment. Context lookups cover offer, item, asset, and build records; asset context IDs may match either `artifactId` or `id`. When enrichment is unavailable or times out, the changelog record is still returned with `metadata.context` set to `null`.
+
 ## Deprecations
 
 Deprecated fields and endpoints remain available only for a compatibility window. Prefer replacement fields from the OpenAPI reference as soon as they are documented.

--- a/apps/docs/content/docs/regions-pagination-errors.mdx
+++ b/apps/docs/content/docs/regions-pagination-errors.mdx
@@ -21,6 +21,8 @@ Common region examples:
 
 If a region is unsupported or unavailable, routes may fall back to a default region or return an empty result, depending on the endpoint.
 
+Free-game promotion routes normalize availability metadata for clients. `countriesBlacklist` is always an array, `giveaway.offerId` is always present, and `giveaway.platform` is a string for platform-specific promotions or `null` otherwise.
+
 ## Pagination
 
 Paginated endpoints use query parameters such as `page`, `limit`, `offset`, or route-specific cursors. Prefer the names documented on each OpenAPI operation.

--- a/openapi/egdata.openapi.json
+++ b/openapi/egdata.openapi.json
@@ -7042,6 +7042,82 @@
           }
         }
       },
+      "Giveaway": {
+        "type": "object",
+        "description": "Free-game promotion metadata.",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "offerId": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "namespace": {
+            "type": "string",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "historical": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "FreeGameOffer": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Offer"
+          },
+          {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "countriesBlacklist",
+              "giveaway"
+            ],
+            "properties": {
+              "countriesBlacklist": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "giveaway": {
+                "$ref": "#/components/schemas/Giveaway"
+              },
+              "price": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Price"
+                  }
+                ],
+                "nullable": true
+              }
+            }
+          }
+        ]
+      },
       "OfferListResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -7682,11 +7758,7 @@
         "type": "array",
         "description": "Current and upcoming Epic free game promotions, enriched with giveaway and regional price data.",
         "items": {
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Offer"
-            }
-          ]
+          "$ref": "#/components/schemas/FreeGameOffer"
         }
       },
       "ChangelogEntry": {

--- a/openapi/egdata.openapi.json
+++ b/openapi/egdata.openapi.json
@@ -5997,6 +5997,135 @@
         }
       }
     },
+    "/changelist": {
+      "get": {
+        "operationId": "listChangelist",
+        "tags": [
+          "Changelog"
+        ],
+        "summary": "List recent changelog records",
+        "description": "Returns recent changelog entries with best-effort `metadata.context` enrichment. Context is null when unavailable.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "$ref": "#/components/parameters/limit"
+          }
+        ],
+        "x-egdata-visibility": "public",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChangelogEntry"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/changelist/{id}": {
+      "get": {
+        "operationId": "getChangelistEntry",
+        "tags": [
+          "Changelog"
+        ],
+        "summary": "Get a changelog record",
+        "description": "Returns a single changelog entry with best-effort `metadata.context` enrichment. Missing changelog IDs return 404.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Mongo changelog document identifier.",
+            "schema": {
+              "type": "string",
+              "example": "6a2ac641bfc3cf2a0efc8507"
+            }
+          }
+        ],
+        "x-egdata-visibility": "public",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangelogEntry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/search/changelog": {
       "get": {
         "operationId": "searchChangelog",
@@ -6004,6 +6133,7 @@
           "Search"
         ],
         "summary": "Search changelog records",
+        "description": "Searches changelog entries and hydrates `metadata.changes[].oldValue` and `newValue` from canonical Mongo records or raw OpenSearch values. Search hits include best-effort `document` enrichment.",
         "parameters": [
           {
             "name": "query",
@@ -7665,6 +7795,106 @@
           }
         }
       },
+      "ChangelogChange": {
+        "type": "object",
+        "description": "Single field-level changelog delta.",
+        "additionalProperties": true,
+        "properties": {
+          "changeType": {
+            "type": "string",
+            "nullable": true
+          },
+          "action": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "field": {
+            "type": "string",
+            "nullable": true
+          },
+          "oldValue": {
+            "description": "Parsed changelog value. May be an object, array, boolean, number, string, or null.",
+            "nullable": true
+          },
+          "newValue": {
+            "description": "Parsed changelog value. May be an object, array, boolean, number, string, or null.",
+            "nullable": true
+          },
+          "oldValueRaw": {
+            "description": "Raw OpenSearch value retained for compatibility when present.",
+            "nullable": true
+          },
+          "newValueRaw": {
+            "description": "Raw OpenSearch value retained for compatibility when present.",
+            "nullable": true
+          }
+        }
+      },
+      "ChangelogContext": {
+        "type": "object",
+        "description": "Best-effort context document for a changelog entry. Null when enrichment is unavailable.",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "artifactId": {
+            "type": "string",
+            "nullable": true
+          },
+          "appName": {
+            "type": "string",
+            "nullable": true
+          },
+          "buildVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "namespace": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ChangelogMetadata": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "contextType": {
+            "type": "string",
+            "nullable": true,
+            "description": "Kind of document that changed, such as offer, item, asset, product-home, or build."
+          },
+          "contextId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Identifier used to resolve the changed document or context."
+          },
+          "context": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangelogContext"
+              }
+            ],
+            "nullable": true
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangelogChange"
+            }
+          }
+        }
+      },
       "Price": {
         "type": "object",
         "description": "Regional offer price from the price engine.",
@@ -7774,8 +8004,29 @@
             "format": "date-time"
           },
           "metadata": {
-            "type": "object",
-            "additionalProperties": true
+            "$ref": "#/components/schemas/ChangelogMetadata"
+          },
+          "document": {
+            "description": "Best-effort document associated with search results. Null when enrichment is unavailable.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Offer"
+              },
+              {
+                "$ref": "#/components/schemas/Item"
+              },
+              {
+                "$ref": "#/components/schemas/Asset"
+              },
+              {
+                "$ref": "#/components/schemas/Build"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
           }
         }
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -918,58 +918,23 @@ app.get("/changelist", async (ctx) => {
     },
   );
 
-  /**
-   * Returns the affected offer, item, asset for each changelog
-   */
-  const elements = await Promise.all(
+  const result = await Promise.all(
     changelist.map(async (change) => {
-      switch (change.metadata.contextType) {
-        case "offer":
-          return Offer.findOne(
-            { id: change.metadata.contextId },
-            {
-              id: 1,
-              title: 1,
-              keyImages: 1,
-              offerType: 1,
-            },
-          );
-        case "item":
-          return Item.findOne(
-            { id: change.metadata.contextId },
-            {
-              id: 1,
-              title: 1,
-              keyImages: 1,
-            },
-          );
-        case "asset":
-          return Asset.findOne(
-            { id: change.metadata.contextId },
-            {
-              id: 1,
-              artifactId: 1,
-            },
-          );
-        default:
-          return null;
-      }
+      const changeObject = change.toObject();
+      const context = await resolveChangelogContextSafely(
+        changeObject.metadata?.contextType,
+        changeObject.metadata?.contextId,
+      );
+
+      return {
+        ...changeObject,
+        metadata: {
+          ...changeObject.metadata,
+          context,
+        },
+      };
     }),
   );
-
-  const result = changelist.map((change) => {
-    const element = elements.find(
-      (e) => e?.toObject().id === change.metadata.contextId,
-    );
-
-    return {
-      ...change.toObject(),
-      metadata: {
-        ...change.toObject().metadata,
-        context: element?.toObject(),
-      },
-    };
-  });
 
   await client.set(cacheKey, JSON.stringify(result), "EX", 60);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import UsersRoute from "./routes/users.js";
 import UsersServiceRoute from "./routes/users-service.js";
 import { attributesToObject } from "./utils/attributes-to-object.js";
 import { countries, regions } from "./utils/countries.js";
+import { resolveChangelogContextSafely } from "./utils/changelog-context.js";
 import { getFeaturedGames } from "./utils/get-featured-games.js";
 import { consola } from "./utils/logger.js";
 import { orderOffersObject } from "./utils/order-offers-object.js";
@@ -997,48 +998,17 @@ app.get("/changelist/:id", async (ctx) => {
     return ctx.json({ message: "Change not found" }, 404);
   }
 
-  let element = null;
-  switch (change.metadata.contextType) {
-    case "offer":
-      element = await Offer.findOne(
-        { id: change.metadata.contextId },
-        {
-          id: 1,
-          title: 1,
-          keyImages: 1,
-          offerType: 1,
-          namespace: 1,
-        },
-      );
-      break;
-    case "item":
-      element = await Item.findOne(
-        { id: change.metadata.contextId },
-        {
-          id: 1,
-          title: 1,
-          keyImages: 1,
-          namespace: 1,
-        },
-      );
-      break;
-    case "asset":
-      element = await Asset.findOne(
-        { id: { $eq: change.metadata.contextId } },
-        {
-          id: 1,
-          artifactId: 1,
-          namespace: 1,
-        },
-      );
-      break;
-  }
+  const changeObject = change.toObject();
+  const context = await resolveChangelogContextSafely(
+    changeObject.metadata?.contextType,
+    changeObject.metadata?.contextId,
+  );
 
   const result = {
-    ...change.toObject(),
+    ...changeObject,
     metadata: {
-      ...change.toObject().metadata,
-      context: element?.toObject(),
+      ...changeObject.metadata,
+      context,
     },
   };
 

--- a/src/openapi/components.ts
+++ b/src/openapi/components.ts
@@ -18,6 +18,12 @@ const flexibleObject = (
   properties,
 });
 
+const changelogValue: OpenAPIV3.SchemaObject = {
+  description:
+    "Parsed changelog value. May be an object, array, boolean, number, string, or null.",
+  nullable: true,
+};
+
 export const commonParameters = {
   country: {
     name: "country",
@@ -636,6 +642,61 @@ export const components: OpenAPIV3.ComponentsObject = {
         offset: { type: "integer" },
       },
     },
+    ChangelogChange: flexibleObject("Single field-level changelog delta.", {
+      changeType: { type: "string", nullable: true },
+      action: { type: "string", nullable: true },
+      type: { type: "string", nullable: true },
+      field: { type: "string", nullable: true },
+      oldValue: changelogValue,
+      newValue: changelogValue,
+      oldValueRaw: {
+        description:
+          "Raw OpenSearch value retained for compatibility when present.",
+        nullable: true,
+      },
+      newValueRaw: {
+        description:
+          "Raw OpenSearch value retained for compatibility when present.",
+        nullable: true,
+      },
+    }),
+    ChangelogContext: flexibleObject(
+      "Best-effort context document for a changelog entry. Null when enrichment is unavailable.",
+      {
+        id: { type: "string", nullable: true },
+        artifactId: { type: "string", nullable: true },
+        appName: { type: "string", nullable: true },
+        buildVersion: { type: "string", nullable: true },
+        title: { type: "string", nullable: true },
+        namespace: { type: "string", nullable: true },
+      },
+    ),
+    ChangelogMetadata: {
+      type: "object",
+      additionalProperties: true,
+      properties: {
+        contextType: {
+          type: "string",
+          nullable: true,
+          description:
+            "Kind of document that changed, such as offer, item, asset, product-home, or build.",
+        },
+        contextId: {
+          type: "string",
+          nullable: true,
+          description:
+            "Identifier used to resolve the changed document or context.",
+        },
+        context: {
+          allOf: [{ $ref: "#/components/schemas/ChangelogContext" }],
+          nullable: true,
+        },
+        changes: {
+          type: "array",
+          items: { $ref: "#/components/schemas/ChangelogChange" },
+        },
+      },
+    },
     Price: flexibleObject("Regional offer price from the price engine.", {
       offerId: { type: "string" },
       region: { type: "string" },
@@ -688,8 +749,22 @@ export const components: OpenAPIV3.ComponentsObject = {
         _id: { type: "string" },
         timestamp: stringDate,
         metadata: {
-          type: "object",
-          additionalProperties: true,
+          $ref: "#/components/schemas/ChangelogMetadata",
+        },
+        document: {
+          description:
+            "Best-effort document associated with search results. Null when enrichment is unavailable.",
+          nullable: true,
+          oneOf: [
+            { $ref: "#/components/schemas/Offer" },
+            { $ref: "#/components/schemas/Item" },
+            { $ref: "#/components/schemas/Asset" },
+            { $ref: "#/components/schemas/Build" },
+            {
+              type: "object",
+              additionalProperties: true,
+            },
+          ],
         },
       },
     ),

--- a/src/openapi/components.ts
+++ b/src/openapi/components.ts
@@ -311,6 +311,44 @@ export const components: OpenAPIV3.ComponentsObject = {
         nullable: true,
       },
     }),
+    Giveaway: flexibleObject("Free-game promotion metadata.", {
+      id: { type: "string", nullable: true },
+      offerId: { type: "string" },
+      platform: { type: "string", nullable: true },
+      title: { type: "string", nullable: true },
+      namespace: { type: "string", nullable: true },
+      startDate: stringDate,
+      endDate: stringDate,
+      historical: {
+        type: "array",
+        nullable: true,
+        items: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+    }),
+    FreeGameOffer: {
+      allOf: [
+        { $ref: "#/components/schemas/Offer" },
+        {
+          type: "object",
+          additionalProperties: true,
+          required: ["countriesBlacklist", "giveaway"],
+          properties: {
+            countriesBlacklist: {
+              type: "array",
+              items: { type: "string" },
+            },
+            giveaway: { $ref: "#/components/schemas/Giveaway" },
+            price: {
+              allOf: [{ $ref: "#/components/schemas/Price" }],
+              nullable: true,
+            },
+          },
+        },
+      ],
+    },
     OfferListResponse: {
       type: "object",
       additionalProperties: false,
@@ -641,7 +679,7 @@ export const components: OpenAPIV3.ComponentsObject = {
       description:
         "Current and upcoming Epic free game promotions, enriched with giveaway and regional price data.",
       items: {
-        allOf: [{ $ref: "#/components/schemas/Offer" }],
+        $ref: "#/components/schemas/FreeGameOffer",
       },
     },
     ChangelogEntry: flexibleObject(

--- a/src/openapi/paths.ts
+++ b/src/openapi/paths.ts
@@ -1213,11 +1213,46 @@ export const paths: EgdataPaths = {
       }),
     }),
   },
+  "/changelist": {
+    get: operation({
+      operationId: "listChangelist",
+      tags: ["Changelog"],
+      summary: "List recent changelog records",
+      description:
+        "Returns recent changelog entries with best-effort `metadata.context` enrichment. Context is null when unavailable.",
+      parameters: pagination,
+      response: arrayOf(ref("ChangelogEntry")),
+    }),
+  },
+  "/changelist/{id}": {
+    get: operation({
+      operationId: "getChangelistEntry",
+      tags: ["Changelog"],
+      summary: "Get a changelog record",
+      description:
+        "Returns a single changelog entry with best-effort `metadata.context` enrichment. Missing changelog IDs return 404.",
+      parameters: [
+        {
+          name: "id",
+          in: "path",
+          required: true,
+          description: "Mongo changelog document identifier.",
+          schema: {
+            type: "string",
+            example: "6a2ac641bfc3cf2a0efc8507",
+          },
+        },
+      ],
+      response: ref("ChangelogEntry"),
+    }),
+  },
   "/search/changelog": {
     get: operation({
       operationId: "searchChangelog",
       tags: ["Search"],
       summary: "Search changelog records",
+      description:
+        "Searches changelog entries and hydrates `metadata.changes[].oldValue` and `newValue` from canonical Mongo records or raw OpenSearch values. Search hits include best-effort `document` enrichment.",
       parameters: [
         stringQuery("query", "Search text."),
         stringQuery("type", "Optional context type filter.", "offer"),

--- a/src/openapi/route-inventory.ts
+++ b/src/openapi/route-inventory.ts
@@ -248,16 +248,6 @@ export const routeClassifications: RouteClassification[] = [
     reason: "Legacy changelog route; search/changelog is documented first.",
   },
   {
-    path: "/changelist/**",
-    visibility: "public-deferred",
-    reason: "Public changelog route; deferred to changelog docs pass.",
-  },
-  {
-    path: "/changelist",
-    visibility: "public-deferred",
-    reason: "Public changelog route; deferred to changelog docs pass.",
-  },
-  {
     path: "/collections/**",
     visibility: "public-deferred",
     reason: "Public collection data; outside first documentation slice.",

--- a/src/routes/free-games.tsx
+++ b/src/routes/free-games.tsx
@@ -25,6 +25,69 @@ import { orderOffersObject } from "../utils/order-offers-object.js";
 
 const app = new Hono();
 
+const toPlainObject = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const candidate = value as { toObject?: unknown };
+  if (typeof candidate.toObject === "function") {
+    return candidate.toObject() as Record<string, unknown>;
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const normalizeCountriesBlacklist = (value: unknown) => {
+  if (Array.isArray(value)) {
+    return value.filter(
+      (country): country is string => typeof country === "string",
+    );
+  }
+
+  if (typeof value === "string" && value.length > 0) {
+    return [value];
+  }
+
+  return [];
+};
+
+const normalizeFreeGamesOffer = (offer: OfferType) => {
+  const orderedOffer = orderOffersObject(offer);
+
+  return {
+    ...orderedOffer,
+    countriesBlacklist: normalizeCountriesBlacklist(
+      orderedOffer.countriesBlacklist,
+    ),
+  };
+};
+
+const normalizeGiveaway = (
+  giveaway: unknown,
+  offerId: string,
+  historical?: unknown,
+) => {
+  const giveawayObject = toPlainObject(giveaway);
+  const normalized: Record<string, unknown> = {
+    ...giveawayObject,
+    offerId:
+      typeof giveawayObject.offerId === "string"
+        ? giveawayObject.offerId
+        : offerId,
+    platform:
+      typeof giveawayObject.platform === "string"
+        ? giveawayObject.platform
+        : null,
+  };
+
+  if (historical !== undefined) {
+    normalized.historical = historical;
+  }
+
+  return normalized;
+};
+
 app.get("/", async (c) => {
   const now = new Date();
   const country = c.req.query("country");
@@ -45,7 +108,7 @@ app.get("/", async (c) => {
 
   const fetchOfferAndPriceAndHistory = async <H,>(
     offerId: string,
-    getHistory: () => Promise<H>,
+    getHistory: () => PromiseLike<H>,
   ) => {
     const [offerR, priceR, histR] = await Promise.allSettled([
       Offer.findOne({ id: offerId }),
@@ -105,26 +168,29 @@ app.get("/", async (c) => {
   const freeGames = unwrap(freeGamesR) ?? [];
   const mobileFreebies = unwrap(mobileFreebiesR) ?? [];
 
-  type Source<G, H> = {
-    list: G[];
-    getOfferId: (g: G) => string;
-    getHistory: (offerId: string) => Promise<H>;
-    toPojo: (g: G) => any;
+  type Source = {
+    list: Array<Record<string, unknown>>;
+    getOfferId: (g: Record<string, unknown>) => string;
+    getHistory: (offerId: string) => PromiseLike<unknown>;
+    toPojo: (g: unknown) => Record<string, unknown>;
   };
 
-  const sources: Array<Source<any, any>> = [
+  const getStringField = (record: Record<string, unknown>, key: string) =>
+    typeof record[key] === "string" ? record[key] : "";
+
+  const sources: Source[] = [
     {
-      list: freeGames,
-      getOfferId: (g: any) => g.id,
+      list: freeGames as Array<Record<string, unknown>>,
+      getOfferId: (g) => getStringField(g, "id"),
       getHistory: (id: string) => FreeGames.find({ id }),
-      toPojo: (g: any) => (typeof g.toObject === "function" ? g.toObject() : g),
+      toPojo: toPlainObject,
     },
     {
-      list: mobileFreebies,
-      getOfferId: (g: any) => g.offerId,
+      list: mobileFreebies as Array<Record<string, unknown>>,
+      getOfferId: (g) => getStringField(g, "offerId"),
       getHistory: (offerId: string) =>
         db.db.collection("mobile-freebies").findOne({ offerId }),
-      toPojo: (g: any) => g, // already POJO
+      toPojo: toPlainObject,
     },
   ];
 
@@ -138,20 +204,23 @@ app.get("/", async (c) => {
         );
 
         if (!offer) {
-          return { giveaway: game };
+          return {
+            giveaway: normalizeGiveaway(
+              src.toPojo(game),
+              offerId,
+              historical ?? null,
+            ),
+          };
         }
 
         const items = await fetchItemsForOffer(offer);
 
         return {
-          ...orderOffersObject(
+          ...normalizeFreeGamesOffer(
             typeof offer.toObject === "function" ? offer.toObject() : offer,
           ),
           items,
-          giveaway: {
-            ...src.toPojo(game),
-            historical: historical ?? (Array.isArray(historical) ? [] : null),
-          },
+          giveaway: normalizeGiveaway(src.toPojo(game), offerId, historical ?? null),
           price: price ?? null,
         };
       }),
@@ -910,8 +979,8 @@ app.get("/mobile", async (c) => {
       });
 
       return {
-        ...orderOffersObject(offer?.toObject()),
-        giveaway: game,
+        ...normalizeFreeGamesOffer(offer?.toObject()),
+        giveaway: normalizeGiveaway(game, game.offerId),
         price: price ?? null,
       };
     }),

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import type { Types } from "@opensearch-project/opensearch";
 import { Hono } from "hono";
 import { getCookie } from "hono/cookie";
-import { ObjectId } from "mongodb";
+import { type Document, type Filter, ObjectId } from "mongodb";
 import { opensearch } from "../clients/opensearch.js";
 import client from "../clients/redis.js";
 import { db } from "../db/index.js";
@@ -223,6 +223,84 @@ const hydrateChangelogValues = async (hits: ChangelogSearchHit[]) => {
       }),
     };
   }
+
+  return hits;
+};
+
+const resolveChangelogSearchDocument = async (
+  contextType?: string,
+  contextId?: string,
+) => {
+  if (!contextType || !contextId) {
+    return null;
+  }
+
+  if (contextType === "offer") {
+    return Offer.findOne({ id: { $eq: contextId } });
+  }
+
+  if (contextType === "item") {
+    return Item.findOne({ id: { $eq: contextId } });
+  }
+
+  if (contextType === "asset") {
+    const asset = await Asset.findOne({
+      $or: [
+        { artifactId: { $eq: contextId } },
+        { id: { $eq: contextId } },
+      ],
+    });
+
+    if (!asset?.itemId) {
+      return null;
+    }
+
+    return Item.findOne({
+      id: { $eq: asset.itemId },
+    });
+  }
+
+  if (contextType === "build") {
+    const filter = (
+      ObjectId.isValid(contextId)
+        ? {
+            $or: [
+              { _id: new ObjectId(contextId) },
+              { _id: { $eq: contextId } },
+            ],
+          }
+        : { _id: { $eq: contextId } }
+    ) as unknown as Filter<Document>;
+
+    return db.db.collection("builds").findOne(filter, {
+      projection: {
+        _id: 1,
+        appName: 1,
+        buildVersion: 1,
+      },
+    });
+  }
+
+  return null;
+};
+
+const enrichChangelogSearchDocuments = async (
+  hits: ChangelogSearchHit[],
+) => {
+  await Promise.all(
+    hits.map(async (hit) => {
+      try {
+        hit.document = await resolveChangelogSearchDocument(
+          hit.metadata?.contextType,
+          hit.metadata?.contextId,
+        );
+      } catch {
+        hit.document = null;
+      }
+
+      return hit;
+    }),
+  );
 
   return hits;
 };
@@ -878,51 +956,7 @@ app.get("/changelog", async (c) => {
 
   await hydrateChangelogValues(hits);
 
-  await Promise.all(
-    hits.map(async (hit) => {
-      if (!hit.metadata?.contextId) {
-        return hit;
-      }
-
-      const contextType = hit.metadata.contextType;
-      const contextId = hit.metadata.contextId;
-
-      if (contextType === "offer") {
-        hit.document = await Offer.findOne({ id: { $eq: contextId } });
-      }
-
-      if (contextType === "item") {
-        hit.document = await Item.findOne({ id: { $eq: contextId } });
-      }
-
-      if (contextType === "asset") {
-        const asset = await Asset.findOne({
-          artifactId: { $eq: contextId },
-        });
-
-        if (!asset?.itemId) {
-          hit.document = null;
-          return hit;
-        }
-
-        hit.document = await Item.findOne({
-          id: { $eq: asset.itemId },
-        });
-      }
-
-      if (contextType === "build") {
-        const build = ObjectId.isValid(contextId)
-          ? await db.db.collection("builds").findOne({
-              _id: new ObjectId(contextId),
-            })
-          : null;
-
-        hit.document = build;
-      }
-
-      return hit;
-    }),
-  );
+  await enrichChangelogSearchDocuments(hits);
 
   const total = response.body.hits.total;
   const estimatedTotalHits =
@@ -954,43 +988,9 @@ app.get("/changelog", async (c) => {
     const fallbackResponseHits = fallbackHits.map((hit) => ({
       ...hit.toObject(),
       _id: String(hit._id),
-    })) as Array<ChangelogType & { _id: string; document?: unknown }>;
+    })) as ChangelogSearchHit[];
 
-    await Promise.all(
-      fallbackResponseHits
-        .filter((hit) => hit.metadata)
-        .map(async (hit) => {
-          const contextType = hit.metadata.contextType;
-          const contextId = hit.metadata.contextId;
-
-          if (contextType === "offer") {
-            hit.document = await Offer.findOne({ id: { $eq: contextId } });
-          }
-
-          if (contextType === "item") {
-            hit.document = await Item.findOne({ id: { $eq: contextId } });
-          }
-
-          if (contextType === "asset") {
-            const asset = await Asset.findOne({ artifactId: { $eq: contextId } });
-            if (!asset?.itemId) {
-              hit.document = null;
-              return hit;
-            }
-
-            hit.document = await Item.findOne({ id: { $eq: asset.itemId } });
-          }
-
-          if (contextType === "build") {
-            const build = await db.db.collection("builds").findOne({
-              _id: new ObjectId(contextId),
-            });
-            hit.document = build;
-          }
-
-          return hit;
-        }),
-    );
+    await enrichChangelogSearchDocuments(fallbackResponseHits);
 
     return c.json(
       {

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -106,6 +106,127 @@ interface PriceQuery {
   "price.discount"?: { $gt: number };
 }
 
+type ChangelogChange = Record<string, unknown> & {
+  oldValue?: unknown;
+  newValue?: unknown;
+  oldValueRaw?: unknown;
+  newValueRaw?: unknown;
+};
+
+type ChangelogSearchHit = ChangelogType & {
+  _id: string;
+  document?: unknown;
+  metadata?: Record<string, unknown> & {
+    contextType?: string;
+    contextId?: string;
+    changes?: ChangelogChange[];
+  };
+};
+
+const hasOwn = (value: object, key: string) => Object.hasOwn(value, key);
+
+const parseChangelogRawValue = (rawValue: unknown) => {
+  if (rawValue === null || rawValue === undefined) {
+    return null;
+  }
+
+  if (typeof rawValue !== "string") {
+    return rawValue;
+  }
+
+  try {
+    return JSON.parse(rawValue);
+  } catch {
+    return rawValue;
+  }
+};
+
+const normalizeChangelogValue = (
+  currentValue: unknown,
+  rawValue: unknown,
+) => {
+  if (currentValue !== null && currentValue !== undefined) {
+    return currentValue;
+  }
+
+  return parseChangelogRawValue(rawValue);
+};
+
+const toPlainChangelog = (
+  document: ChangelogType & { toObject?: () => ChangelogType },
+) => {
+  if (typeof document.toObject === "function") {
+    return document.toObject();
+  }
+
+  return document;
+};
+
+const toMongoIdCandidates = (ids: string[]) => [
+  ...ids
+    .filter((id) => ObjectId.isValid(id))
+    .map((id) => new ObjectId(id)),
+  ...ids,
+];
+
+const hydrateChangelogValues = async (hits: ChangelogSearchHit[]) => {
+  if (hits.length === 0) {
+    return hits;
+  }
+
+  const ids = Array.from(new Set(hits.map((hit) => hit._id).filter(Boolean)));
+  let mongoChangesById = new Map<string, ChangelogType>();
+
+  if (ids.length > 0) {
+    try {
+      const mongoChanges = await Changelog.find({
+        _id: { $in: toMongoIdCandidates(ids) },
+      });
+      mongoChangesById = new Map(
+        mongoChanges.map((change) => {
+          const plainChange = toPlainChangelog(change);
+          return [String(plainChange._id), plainChange];
+        }),
+      );
+    } catch {
+      mongoChangesById = new Map();
+    }
+  }
+
+  for (const hit of hits) {
+    const changes = hit.metadata?.changes;
+    if (!Array.isArray(changes)) {
+      continue;
+    }
+
+    const mongoChange = mongoChangesById.get(String(hit._id));
+    const mongoChangeItems = Array.isArray(mongoChange?.metadata?.changes)
+      ? (mongoChange.metadata.changes as ChangelogChange[])
+      : [];
+
+    hit.metadata = {
+      ...hit.metadata,
+      changes: changes.map((change, index) => {
+        const mongoChangeItem = mongoChangeItems[index];
+        const hydratedChange = { ...change };
+
+        hydratedChange.oldValue =
+          mongoChangeItem && hasOwn(mongoChangeItem, "oldValue")
+            ? mongoChangeItem.oldValue
+            : normalizeChangelogValue(change.oldValue, change.oldValueRaw);
+        hydratedChange.newValue =
+          mongoChangeItem && hasOwn(mongoChangeItem, "newValue")
+            ? mongoChangeItem.newValue
+            : normalizeChangelogValue(change.newValue, change.newValueRaw);
+
+        return hydratedChange;
+      }),
+    };
+  }
+
+  return hits;
+};
+
 function buildBaseQuery(query: SearchBody): MongoQuery {
   const mongoQuery: MongoQuery = {};
 
@@ -211,7 +332,7 @@ function buildPriceQuery(query: SearchBody): PriceQuery {
 function buildSortParams(
   query: SearchBody,
   sort: string,
-  dir: number,
+  dir: 1 | -1,
 ): Record<string, 1 | -1 | { $meta: string }> {
   let sortParams: Record<string, 1 | -1 | { $meta: string }> = {};
 
@@ -314,7 +435,7 @@ app.post("/", async (c) => {
 
   const sort = query.sortBy || "lastModifiedDate";
   const sortDir = query.sortDir || "desc";
-  const dir = sortDir === "asc" ? 1 : -1;
+  const dir: 1 | -1 = sortDir === "asc" ? 1 : -1;
 
   const mongoQuery = buildBaseQuery(query);
   const priceQuery = buildPriceQuery(query);
@@ -746,51 +867,61 @@ app.get("/changelog", async (c) => {
     },
   });
 
-  const hits = response.body.hits.hits.map((hit) => ({
+  const responseHits = response.body.hits.hits as unknown as Array<{
+    _id: string;
+    _source?: ChangelogType;
+  }>;
+  const hits = responseHits.map((hit) => ({
     ...hit._source,
     _id: hit._id,
-  })) as Array<ChangelogType & { _id: string; document?: unknown }>;
+  })) as ChangelogSearchHit[];
+
+  await hydrateChangelogValues(hits);
 
   await Promise.all(
-    hits
-      .filter((hit) => hit.metadata)
-      .map(async (hit) => {
-        const contextType = hit.metadata.contextType;
-        const contextId = hit.metadata.contextId;
-
-        if (contextType === "offer") {
-          hit.document = await Offer.findOne({ id: { $eq: contextId } });
-        }
-
-        if (contextType === "item") {
-          hit.document = await Item.findOne({ id: { $eq: contextId } });
-        }
-
-        if (contextType === "asset") {
-          const asset = await Asset.findOne({
-            artifactId: { $eq: contextId },
-          });
-
-          if (!asset?.itemId) {
-            hit.document = null;
-            return hit;
-          }
-
-          hit.document = await Item.findOne({
-            id: { $eq: asset.itemId },
-          });
-        }
-
-        if (contextType === "build") {
-          const build = await db.db.collection("builds").findOne({
-            _id: new ObjectId(contextId),
-          });
-
-          hit.document = build;
-        }
-
+    hits.map(async (hit) => {
+      if (!hit.metadata?.contextId) {
         return hit;
-      }),
+      }
+
+      const contextType = hit.metadata.contextType;
+      const contextId = hit.metadata.contextId;
+
+      if (contextType === "offer") {
+        hit.document = await Offer.findOne({ id: { $eq: contextId } });
+      }
+
+      if (contextType === "item") {
+        hit.document = await Item.findOne({ id: { $eq: contextId } });
+      }
+
+      if (contextType === "asset") {
+        const asset = await Asset.findOne({
+          artifactId: { $eq: contextId },
+        });
+
+        if (!asset?.itemId) {
+          hit.document = null;
+          return hit;
+        }
+
+        hit.document = await Item.findOne({
+          id: { $eq: asset.itemId },
+        });
+      }
+
+      if (contextType === "build") {
+        const build = ObjectId.isValid(contextId)
+          ? await db.db.collection("builds").findOne({
+              _id: new ObjectId(contextId),
+            })
+          : null;
+
+        hit.document = build;
+      }
+
+      return hit;
+    }),
   );
 
   const total = response.body.hits.total;

--- a/src/utils/changelog-context.ts
+++ b/src/utils/changelog-context.ts
@@ -1,0 +1,99 @@
+import { type Document, type Filter, ObjectId } from "mongodb";
+import { db } from "../db/index.js";
+import { Asset, Item, Offer } from "../models/index.js";
+
+type ContextDocument = Record<string, unknown> & {
+  toObject?: () => Record<string, unknown>;
+};
+
+const toPlainContext = (document: ContextDocument | null) => {
+  if (!document) {
+    return null;
+  }
+
+  if (typeof document.toObject === "function") {
+    return document.toObject();
+  }
+
+  return document;
+};
+
+const buildIdFilter = (contextId: string): Filter<Document> => {
+  if (!ObjectId.isValid(contextId)) {
+    return { _id: { $eq: contextId } } as unknown as Filter<Document>;
+  }
+
+  return {
+    $or: [{ _id: new ObjectId(contextId) }, { _id: { $eq: contextId } }],
+  } as unknown as Filter<Document>;
+};
+
+export const resolveChangelogContext = async (
+  contextType?: string,
+  contextId?: string,
+) => {
+  if (!contextType || !contextId) {
+    return null;
+  }
+
+  switch (contextType) {
+    case "offer":
+      return toPlainContext(
+        await Offer.findOne(
+          { id: { $eq: contextId } },
+          {
+            id: 1,
+            title: 1,
+            keyImages: 1,
+            offerType: 1,
+            namespace: 1,
+          },
+        ),
+      );
+    case "item":
+      return toPlainContext(
+        await Item.findOne(
+          { id: { $eq: contextId } },
+          {
+            id: 1,
+            title: 1,
+            keyImages: 1,
+            namespace: 1,
+          },
+        ),
+      );
+    case "asset":
+      return toPlainContext(
+        await Asset.findOne(
+          {
+            $or: [
+              { artifactId: { $eq: contextId } },
+              { id: { $eq: contextId } },
+            ],
+          },
+          {
+            id: 1,
+            artifactId: 1,
+            namespace: 1,
+          },
+        ),
+      );
+    case "build":
+      return toPlainContext(
+        await db.db.collection("builds").findOne(buildIdFilter(contextId)),
+      );
+    default:
+      return null;
+  }
+};
+
+export const resolveChangelogContextSafely = async (
+  contextType?: string,
+  contextId?: string,
+) => {
+  try {
+    return await resolveChangelogContext(contextType, contextId);
+  } catch {
+    return null;
+  }
+};

--- a/src/utils/changelog-context.ts
+++ b/src/utils/changelog-context.ts
@@ -66,6 +66,7 @@ export const resolveChangelogContext = async (
       return toPlainContext(
         await Asset.findOne(
           {
+            // Changelog producers may store either asset.artifactId or asset.id.
             $or: [
               { artifactId: { $eq: contextId } },
               { id: { $eq: contextId } },
@@ -80,7 +81,13 @@ export const resolveChangelogContext = async (
       );
     case "build":
       return toPlainContext(
-        await db.db.collection("builds").findOne(buildIdFilter(contextId)),
+        await db.db.collection("builds").findOne(buildIdFilter(contextId), {
+          projection: {
+            _id: 1,
+            appName: 1,
+            buildVersion: 1,
+          },
+        }),
       );
     default:
       return null;

--- a/tests/changelog-context.test.ts
+++ b/tests/changelog-context.test.ts
@@ -42,6 +42,55 @@ describe("changelog context resolver", () => {
     vi.clearAllMocks();
   });
 
+  it("resolves offer context", async () => {
+    const offer = {
+      id: "offer-1",
+      title: "Offer One",
+      namespace: "sandbox-1",
+    };
+    mocks.offerFindOne.mockResolvedValue({
+      toObject: () => offer,
+    });
+
+    const context = await resolveChangelogContext("offer", "offer-1");
+
+    expect(context).toEqual(offer);
+    expect(mocks.offerFindOne).toHaveBeenCalledWith(
+      { id: { $eq: "offer-1" } },
+      {
+        id: 1,
+        title: 1,
+        keyImages: 1,
+        offerType: 1,
+        namespace: 1,
+      },
+    );
+  });
+
+  it("resolves item context", async () => {
+    const item = {
+      id: "item-1",
+      title: "Item One",
+      namespace: "sandbox-1",
+    };
+    mocks.itemFindOne.mockResolvedValue({
+      toObject: () => item,
+    });
+
+    const context = await resolveChangelogContext("item", "item-1");
+
+    expect(context).toEqual(item);
+    expect(mocks.itemFindOne).toHaveBeenCalledWith(
+      { id: { $eq: "item-1" } },
+      {
+        id: 1,
+        title: 1,
+        keyImages: 1,
+        namespace: 1,
+      },
+    );
+  });
+
   it("resolves asset context by artifactId or id", async () => {
     const asset = {
       artifactId: "artifact-1",
@@ -82,9 +131,59 @@ describe("changelog context resolver", () => {
 
     expect(context).toEqual(build);
     expect(mocks.collection).toHaveBeenCalledWith("builds");
-    const filter = mocks.buildsFindOne.mock.calls[0][0];
-    expect(filter.$or[0]._id.toString()).toBe(buildId.toString());
-    expect(filter.$or[1]._id.$eq).toBe(buildId.toString());
+    const [filter, options] = mocks.buildsFindOne.mock.calls[0];
+    const filters = filter.$or.map((entry: Record<string, unknown>) => {
+      const id = entry._id as ObjectId | { $eq: string };
+      return id instanceof ObjectId ? id.toString() : id.$eq;
+    });
+    expect(filters).toEqual(
+      expect.arrayContaining([buildId.toString(), buildId.toString()]),
+    );
+    expect(options).toEqual({
+      projection: {
+        _id: 1,
+        appName: 1,
+        buildVersion: 1,
+      },
+    });
+  });
+
+  it("resolves build context by non-ObjectId string", async () => {
+    const build = {
+      _id: "legacy-build-id",
+      appName: "test-build",
+      buildVersion: "1.0.0",
+    };
+    mocks.buildsFindOne.mockResolvedValue(build);
+
+    const context = await resolveChangelogContext("build", "legacy-build-id");
+
+    expect(context).toEqual(build);
+    expect(mocks.buildsFindOne).toHaveBeenCalledWith(
+      { _id: { $eq: "legacy-build-id" } },
+      {
+        projection: {
+          _id: 1,
+          appName: 1,
+          buildVersion: 1,
+        },
+      },
+    );
+  });
+
+  it("returns null for missing args and unknown context types", async () => {
+    await expect(resolveChangelogContext()).resolves.toBeNull();
+    await expect(
+      resolveChangelogContext("offer", null as unknown as string),
+    ).resolves.toBeNull();
+    await expect(
+      resolveChangelogContext("unknown", "context-1"),
+    ).resolves.toBeNull();
+
+    expect(mocks.offerFindOne).not.toHaveBeenCalled();
+    expect(mocks.itemFindOne).not.toHaveBeenCalled();
+    expect(mocks.assetFindOne).not.toHaveBeenCalled();
+    expect(mocks.buildsFindOne).not.toHaveBeenCalled();
   });
 
   it("returns null when safe context enrichment fails", async () => {

--- a/tests/changelog-context.test.ts
+++ b/tests/changelog-context.test.ts
@@ -1,0 +1,97 @@
+import { ObjectId } from "mongodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveChangelogContext,
+  resolveChangelogContextSafely,
+} from "../src/utils/changelog-context.js";
+
+const mocks = vi.hoisted(() => {
+  const buildsFindOne = vi.fn();
+
+  return {
+    assetFindOne: vi.fn(),
+    buildsFindOne,
+    collection: vi.fn(() => ({ findOne: buildsFindOne })),
+    itemFindOne: vi.fn(),
+    offerFindOne: vi.fn(),
+  };
+});
+
+vi.mock("../src/models/index.js", () => ({
+  Asset: {
+    findOne: mocks.assetFindOne,
+  },
+  Item: {
+    findOne: mocks.itemFindOne,
+  },
+  Offer: {
+    findOne: mocks.offerFindOne,
+  },
+}));
+
+vi.mock("../src/db/index.js", () => ({
+  db: {
+    db: {
+      collection: mocks.collection,
+    },
+  },
+}));
+
+describe("changelog context resolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves asset context by artifactId or id", async () => {
+    const asset = {
+      artifactId: "artifact-1",
+      id: "asset-1",
+      namespace: "sandbox-1",
+    };
+    mocks.assetFindOne.mockResolvedValue({
+      toObject: () => asset,
+    });
+
+    const context = await resolveChangelogContext("asset", "artifact-1");
+
+    expect(context).toEqual(asset);
+    expect(mocks.assetFindOne).toHaveBeenCalledWith(
+      {
+        $or: [
+          { artifactId: { $eq: "artifact-1" } },
+          { id: { $eq: "artifact-1" } },
+        ],
+      },
+      {
+        id: 1,
+        artifactId: 1,
+        namespace: 1,
+      },
+    );
+  });
+
+  it("resolves build context by ObjectId string", async () => {
+    const buildId = new ObjectId();
+    const build = {
+      _id: buildId,
+      appName: "test-build",
+    };
+    mocks.buildsFindOne.mockResolvedValue(build);
+
+    const context = await resolveChangelogContext("build", buildId.toString());
+
+    expect(context).toEqual(build);
+    expect(mocks.collection).toHaveBeenCalledWith("builds");
+    const filter = mocks.buildsFindOne.mock.calls[0][0];
+    expect(filter.$or[0]._id.toString()).toBe(buildId.toString());
+    expect(filter.$or[1]._id.$eq).toBe(buildId.toString());
+  });
+
+  it("returns null when safe context enrichment fails", async () => {
+    mocks.assetFindOne.mockRejectedValue(new Error("lookup timed out"));
+
+    const context = await resolveChangelogContextSafely("asset", "artifact-1");
+
+    expect(context).toBeNull();
+  });
+});

--- a/tests/search-route.test.ts
+++ b/tests/search-route.test.ts
@@ -8,7 +8,7 @@ import {
   it,
   vi,
 } from "vitest";
-import { Changelog } from "../src/models/index.js";
+import { Changelog, Offer } from "../src/models/index.js";
 import SearchRoute from "../src/routes/search.js";
 import { loadSeaQaOffers, type SeaQaOffer } from "./fixtures/seaqa.js";
 
@@ -327,5 +327,32 @@ describe("search route with SeaQA fixtures", () => {
     expect(deleteChange.oldValue).toBe(42);
     expect(deleteChange.newValue).toBeNull();
     expect(arrayChange.oldValueRaw).toBe("[1,2]");
+  });
+
+  it("keeps /search/changelog available when document enrichment fails", async () => {
+    const id = "6a2abf73cdd9e513e4910af1";
+    mocks.opensearchSearch.mockResolvedValueOnce(
+      changelogSearchResponse([
+        {
+          _id: id,
+          _source: {
+            timestamp: "2026-06-11T14:00:00.000Z",
+            metadata: {
+              contextType: "offer",
+              contextId: "offer-1",
+              changes: [],
+            },
+          },
+        },
+      ]),
+    );
+    mockChangelogFind([]);
+    vi.spyOn(Offer, "findOne").mockRejectedValue(new Error("lookup timed out"));
+
+    const res = await app.request("/search/changelog?query=&page=1&limit=1");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.hits[0].document).toBeNull();
   });
 });

--- a/tests/search-route.test.ts
+++ b/tests/search-route.test.ts
@@ -8,6 +8,7 @@ import {
   it,
   vi,
 } from "vitest";
+import { Changelog } from "../src/models/index.js";
 import SearchRoute from "../src/routes/search.js";
 import { loadSeaQaOffers, type SeaQaOffer } from "./fixtures/seaqa.js";
 
@@ -22,6 +23,26 @@ const mocks = vi.hoisted(() => ({
   opensearchSearch: vi.fn(),
   redisSet: vi.fn(),
 }));
+
+const changelogSearchResponse = (
+  hits: Array<{ _id: string; _source: Record<string, unknown> }>,
+) => ({
+  body: {
+    took: 5,
+    timed_out: false,
+    hits: {
+      total: { value: hits.length, relation: "eq" },
+      hits,
+    },
+  },
+});
+
+const mockChangelogFind = (documents: unknown[]) =>
+  vi
+    .spyOn(Changelog, "find")
+    .mockReturnValue(
+      Promise.resolve(documents) as unknown as ReturnType<typeof Changelog.find>,
+    );
 
 vi.mock("../src/clients/opensearch.js", () => ({
   opensearch: {
@@ -89,6 +110,7 @@ describe("search route with SeaQA fixtures", () => {
 
   afterEach(() => {
     consoleLogSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   it("maps fixture-backed OpenSearch hits through /search/v2/search", async () => {
@@ -190,5 +212,120 @@ describe("search route with SeaQA fixtures", () => {
         }),
       }),
     );
+  });
+
+  it("hydrates /search/changelog old and new values from Mongo", async () => {
+    const id = "6a2ac641bfc3cf2a0efc8507";
+    mocks.opensearchSearch.mockResolvedValueOnce(
+      changelogSearchResponse([
+        {
+          _id: id,
+          _source: {
+            timestamp: "2026-06-11T14:29:00.000Z",
+            metadata: {
+              contextType: "product-home",
+              contextId: "home-page",
+              changes: [
+                {
+                  changeType: "update",
+                  field: "hero",
+                  oldValue: null,
+                  newValue: null,
+                  oldValueRaw: '{"title":"indexed old"}',
+                  newValueRaw: '{"title":"indexed new"}',
+                },
+              ],
+            },
+          },
+        },
+      ]),
+    );
+    mockChangelogFind([
+      {
+        _id: id,
+        metadata: {
+          changes: [
+            {
+              changeType: "update",
+              field: "hero",
+              oldValue: { title: "mongo old" },
+              newValue: { title: "mongo new" },
+            },
+          ],
+        },
+        toObject() {
+          return this;
+        },
+      },
+    ]);
+
+    const res = await app.request("/search/changelog?query=&page=1&limit=1");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const change = body.hits[0].metadata.changes[0];
+    expect(change.oldValue).toEqual({ title: "mongo old" });
+    expect(change.newValue).toEqual({ title: "mongo new" });
+    expect(change.oldValueRaw).toBe('{"title":"indexed old"}');
+    expect(change.newValueRaw).toBe('{"title":"indexed new"}');
+  });
+
+  it("hydrates /search/changelog values from raw OpenSearch values", async () => {
+    const id = "6a2abf73cdd9e513e4910af0";
+    mocks.opensearchSearch.mockResolvedValueOnce(
+      changelogSearchResponse([
+        {
+          _id: id,
+          _source: {
+            timestamp: "2026-06-11T14:00:00.000Z",
+            metadata: {
+              contextType: "product-home",
+              contextId: "home-page",
+              changes: [
+                {
+                  changeType: "update",
+                  field: "array",
+                  oldValue: null,
+                  newValue: null,
+                  oldValueRaw: "[1,2]",
+                  newValueRaw: '{"ok":true}',
+                },
+                {
+                  changeType: "update",
+                  field: "string",
+                  oldValue: null,
+                  newValue: null,
+                  oldValueRaw: '"quoted"',
+                  newValueRaw: "plain text",
+                },
+                {
+                  changeType: "delete",
+                  field: "removed",
+                  oldValue: null,
+                  newValue: null,
+                  oldValueRaw: "42",
+                  newValueRaw: null,
+                },
+              ],
+            },
+          },
+        },
+      ]),
+    );
+    mockChangelogFind([]);
+
+    const res = await app.request("/search/changelog?query=&page=1&limit=1");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const [arrayChange, stringChange, deleteChange] =
+      body.hits[0].metadata.changes;
+    expect(arrayChange.oldValue).toEqual([1, 2]);
+    expect(arrayChange.newValue).toEqual({ ok: true });
+    expect(stringChange.oldValue).toBe("quoted");
+    expect(stringChange.newValue).toBe("plain text");
+    expect(deleteChange.oldValue).toBe(42);
+    expect(deleteChange.newValue).toBeNull();
+    expect(arrayChange.oldValueRaw).toBe("[1,2]");
   });
 });


### PR DESCRIPTION
## Summary
- Hydrate `/search/changelog` responses so `metadata.changes[].oldValue` and `newValue` are usable again, falling back to parsed raw values when needed.
- Harden `/changelist/:id` context enrichment so lookup failures do not block the changelog payload, and expand asset/build resolution.
- Add focused regression coverage for Mongo hydration, raw-value parsing, null semantics, and safe context resolution.

## Testing
- Passed targeted Vitest coverage for `search-route` and the new changelog context helper.
- Passed a narrow TypeScript check for the changed route/helper/test files.
- Passed `openapi:generate`, `docs:check`, and `release:check`.
- `pnpm typecheck` and full `pnpm biome check .` still fail on existing repo-wide docs/dependency baseline issues outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced changelog search responses with improved hydration of old and new change values
  * Made changelist detail context enrichment more resilient with safer resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->